### PR TITLE
move build defs from release to repo-infra

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "io_kubernetes_build")

--- a/defs/BUILD
+++ b/defs/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+py_binary(
+    name = "gcs_uploader",
+    srcs = [
+        "gcs_uploader.py",
+    ],
+)

--- a/defs/build.bzl
+++ b/defs/build.bzl
@@ -1,0 +1,43 @@
+def _gcs_upload_impl(ctx):
+  targets = []
+  for target in ctx.files.data:
+    targets.append(target.short_path)
+
+  ctx.file_action(
+      output = ctx.outputs.targets,
+      content  = "\n".join(targets),
+  )
+
+  ctx.file_action(
+      content = "%s --manifest %s --root $PWD -- $@" % (
+          ctx.attr.uploader.files_to_run.executable.short_path,
+          ctx.outputs.targets.short_path,
+      ),
+      output = ctx.outputs.executable,
+      executable = True,
+  )
+
+  return struct(
+      runfiles = ctx.runfiles(
+          files = ctx.files.data + ctx.files.uploader +
+            [ctx.version_file, ctx.outputs.targets]
+          )
+      )
+
+gcs_upload = rule(
+    attrs = {
+        "data": attr.label_list(
+            mandatory = True,
+            allow_files = True,
+        ),
+        "uploader": attr.label(
+            default = Label("//defs:gcs_uploader"),
+            allow_files = True,
+        ),
+    },
+    executable = True,
+    outputs = {
+        "targets": "%{name}-targets.txt",
+    },
+    implementation = _gcs_upload_impl,
+)

--- a/defs/deb.bzl
+++ b/defs/deb.bzl
@@ -1,0 +1,34 @@
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar", "pkg_deb")
+
+KUBERNETES_AUTHORS = "Kubernetes Authors <kubernetes-dev+release@googlegroups.com>"
+
+KUBERNETES_HOMEPAGE = "http://kubernetes.io"
+
+def k8s_deb(name, depends = [], description = ""):
+  pkg_deb(
+      name = name,
+      architecture = "amd64",
+      data = name + "-data",
+      depends = depends,
+      description = description,
+      homepage = KUBERNETES_HOMEPAGE,
+      maintainer = KUBERNETES_AUTHORS,
+      package =  name,
+      version = "1.6.0-alpha",
+  )
+
+def deb_data(name, data = []):
+  deps = []
+  for i, info in enumerate(data):
+    dname = "%s-deb-data-%s" % (name, i)
+    deps += [dname]
+    pkg_tar(
+        name = dname,
+        files = info["files"],
+        mode = info["mode"],
+        package_dir = info["dir"],
+    )
+  pkg_tar(
+      name = name + "-data",
+      deps = deps,
+  )

--- a/defs/gcs_uploader.py
+++ b/defs/gcs_uploader.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import atexit
+import os
+import os.path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+def main(argv):
+    scratch = tempfile.mkdtemp(prefix="bazel-gcs.")
+    atexit.register(lambda: shutil.rmtree(scratch))
+
+    with open(argv.manifest) as manifest:
+        for artifact in manifest:
+            artifact = artifact.strip()
+            try:
+                os.makedirs(os.path.join(scratch, os.path.dirname(artifact)))
+            except (OSError):
+                # skip directory already exists errors
+                pass
+            os.symlink(os.path.join(argv.root, artifact), os.path.join(scratch, artifact))
+
+    sys.exit(subprocess.call(["gsutil", "-m", "rsync", "-C", "-r", scratch, argv.gcs_path]))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Upload build targets to GCS.')
+
+    parser.add_argument("--manifest", required=True, help="path to manifest of targets")
+    parser.add_argument("--root", required=True, help="path to root of workspace")
+    parser.add_argument("gcs_path", help="path in gcs to push targets")
+
+    main(parser.parse_args())


### PR DESCRIPTION
They originally went to release because there was no
good place to put them.