### PR TITLE
Run buildifier on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ go:
   - master
 
 before_install:
- - go get -u github.com/alecthomas/gometalinter
+  - go get -u github.com/alecthomas/gometalinter
 
 install:
   - gometalinter --install
+  - go get -u github.com/bazelbuild/buildifier/buildifier
 
 build:
   - true
@@ -15,3 +16,4 @@ build:
 script:
   - verify/verify-boilerplate.sh --rootdir="${TRAVIS_BUILD_DIR}" -v
   - verify/verify-go-src.sh --rootdir "${TRAVIS_BUILD_DIR}" -v
+  - buildifier -mode=check $(find . -name BUILD -o -name '*.bzl' -type f)


### PR DESCRIPTION
Most of our Bazel-enabled repos already check BUILD formatting through gazel, so we don't need to run buildifier there (or create a generic buildifier verification script).

We don't yet have any checks on this repo, however, where we have some Skylark files, so let's enforce proper style.