### PR TITLE
Allow go_genrule to work from external dependencies.

### DIFF
--- a/defs/go.bzl
+++ b/defs/go.bzl
@@ -21,13 +21,29 @@ go_sources_aspect = aspect(
 )
 
 def _compute_genrule_command(ctx):
+  workspace_root = '$$(pwd)'
+  if ctx.build_file_path.startswith('external/'):
+    # We want GO_WORKSPACE to point at the root directory of the Bazel
+    # workspace containing this go_genrule's BUILD file. If it's being
+    # included in a different workspace as an external dependency, the
+    # link target must point to the external subtree instead of the main
+    # workspace (which contains code we don't care about).
+    #
+    # Given a build file path like "external/foo/bar/BUILD", the following
+    # slash split+join sets external_dep_prefix to "external/foo" and the
+    # effective workspace root to "$PWD/external/foo/".
+    external_dep_prefix = '/'.join(ctx.build_file_path.split('/')[:2])
+    workspace_root = '$$(pwd)/' + external_dep_prefix
+
   cmd = [
       'set -e',
       # setup main GOPATH
       'export GOPATH=/tmp/gopath',
       'export GO_WORKSPACE=$${GOPATH}/src/' + ctx.attr.go_prefix.go_prefix,
       'mkdir -p $${GO_WORKSPACE%/*}',
-      'ln -s $$(pwd) $${GO_WORKSPACE}',
+      'ln -s %s/ $${GO_WORKSPACE}' % (workspace_root,),
+      'if [[ ! -e $${GO_WORKSPACE}/external ]]; then ln -s $$(pwd)/external/ $${GO_WORKSPACE}/; fi',
+      'if [[ ! -e $${GO_WORKSPACE}/bazel-out ]]; then ln -s $$(pwd)/bazel-out/ $${GO_WORKSPACE}/; fi',
       # setup genfile GOPATH
       'export GENGOPATH=/tmp/gengopath',
       'export GENGO_WORKSPACE=$${GENGOPATH}/src/' + ctx.attr.go_prefix.go_prefix,


### PR DESCRIPTION
The previous code assumed that `$(pwd)` was the root of the workspace that
uses `go_genrule`. This isn't true when using Bazel's external
dependencies, which place the code under `external/${DEP_NAME}/`.

This change is a bit hacky. Ideally the `go_genrule` implementation
wouldn't make assumptions about the code layout and would use
`$(location)` to find paths, but that would be a much larger change.
Special-casing build paths starting with `external/` was easier and
non-invasive.