### PR TITLE
Add ManageGoRules option to kazel

### DIFF
--- a/kazel/config.go
+++ b/kazel/config.go
@@ -35,6 +35,9 @@ type Cfg struct {
 	VendorMultipleBuildFiles bool
 	// whether to manage kubernetes' pkg/generated/openapi.
 	K8sOpenAPIGen bool
+	// Whether to manage the upstream Go rules provided by bazelbuild/rules_go.
+	// If using gazelle, set this to false (or omit).
+	ManageGoRules bool
 }
 
 // ReadCfg reads and unmarshals the specified json file into a Cfg struct.


### PR DESCRIPTION
This should allow us to use `gazelle` along with the sourcerer and generator functionality we need from `kazel`. Part of https://github.com/kubernetes/kubernetes/issues/47558.

It is a bit messy. At some point we should probably refactor this to remove all of the go-rule functionality that we no longer need.

I've tested this on `repo-infra`, where it basically seems to work. I'll try a larger test on `test-infra` next.

/assign @mikedanese @spxtr 