### PR TITLE
Additional gazelle-compatibility fixes

### DIFF
--- a/kazel/generator.go
+++ b/kazel/generator.go
@@ -106,6 +106,12 @@ func (v *Vendorer) addGeneratedOpenAPIRule(paths []string) error {
 	sort.Strings(vendorTargets)
 
 	pkgPath := filepath.Join("pkg", "generated", "openapi")
+	// If we haven't walked this package yet, walk it so there is a go_library rule to modify
+	if len(v.newRules[pkgPath]) == 0 {
+		if err := v.updateSinglePkg(pkgPath); err != nil {
+			return err
+		}
+	}
 	for _, r := range v.newRules[pkgPath] {
 		if r.Name() == "go_default_library" {
 			r.SetAttr("openapi_targets", asExpr(openAPITargets))

--- a/kazel/kazel.go
+++ b/kazel/kazel.go
@@ -64,11 +64,13 @@ func main() {
 		glog.Fatalf("cannot chdir into root %q: %v", v.root, err)
 	}
 
-	if err = v.walkVendor(); err != nil {
-		glog.Fatalf("err walking vendor: %v", err)
-	}
-	if err = v.walkRepo(); err != nil {
-		glog.Fatalf("err walking repo: %v", err)
+	if v.cfg.ManageGoRules {
+		if err = v.walkVendor(); err != nil {
+			glog.Fatalf("err walking vendor: %v", err)
+		}
+		if err = v.walkRepo(); err != nil {
+			glog.Fatalf("err walking repo: %v", err)
+		}
 	}
 	if err = v.walkGenerated(); err != nil {
 		glog.Fatalf("err walking generated: %v", err)

--- a/kazel/kazel.go
+++ b/kazel/kazel.go
@@ -174,10 +174,6 @@ func writeHeaders(file *bzl.File) {
 		[]bzl.Expr{
 			pkgRule.Call,
 			&bzl.CallExpr{
-				X:    &bzl.LiteralExpr{Token: "licenses"},
-				List: []bzl.Expr{asExpr([]string{"notice"})},
-			},
-			&bzl.CallExpr{
 				X: &bzl.LiteralExpr{Token: "load"},
 				List: asExpr([]string{
 					"@io_bazel_rules_go//go:def.bzl",

--- a/kazel/sourcerer.go
+++ b/kazel/sourcerer.go
@@ -101,6 +101,8 @@ func (v *Vendorer) walkSource(pkgPath string) ([]string, error) {
 			func(_ ruleType) string { return allSrcsTarget },
 			map[string]bzl.Expr{
 				"srcs": asExpr(append(children, fmt.Sprintf(":%s", pkgSrcsTarget))),
+				// TODO: should this be more restricted?
+				"visibility": asExpr([]string{"//visibility:public"}),
 			}),
 	})
 	return []string{fmt.Sprintf("//%s:%s", pkgPath, allSrcsTarget)}, nil


### PR DESCRIPTION
More testing revealed that my fix in #27 for the openapi generated rules was problematic:
* even with `ManageGoRules = false`, `kazel` would add rules under `vendor/` depending on the setting of `VendorMultipleBuildFiles` matching what `gazelle` was going
* similarly, it would add `cgo_genrule` rules (which `gazelle` no longer uses)

Instead, this only walks the tree when necessary, and instead explicitly updates the `pkg/generated/openapi` package if necessary.

Additional changes:
* `all-srcs` rules are now declared with public visibility, since we may not have a default visibility set anymore
* `licenses()` rules are no longer added to new files, since they aren't really used in bazel and were probably wrong to start with

/assign @spxtr @mikedanese 