### PR TITLE
Fix: Modify the entry level in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ After this command, you will have:
 1.  A `repo-infra` directory in your project containing the content of **this**
     project
 2.  2 new commits in the active branch:
-  1.  A commit that squashes the git history of the `repo-infra` project
-  2.  A merge commit whose ancestors are:
-    1.  The `HEAD` of the branch prior to when you ran `git subtree add`
-    2.  The commit containing the squashed `repo-infra` commits
+    1.  A commit that squashes the git history of the `repo-infra` project
+    2.  A merge commit whose ancestors are:
+        1.  The `HEAD` of the branch prior to when you ran `git subtree add`
+        2.  The commit containing the squashed `repo-infra` commits
 


### PR DESCRIPTION
I see the entry level in the end of README.md is incorrect， it‘s 1-6 now. But in fact  it should  be like:
1...
2... 
---i...
---ii...
------a...
------b...
So I fix it.