### PR TITLE
kazel K8sOpenAPIGen should respect SkippedPaths too

### DIFF
--- a/kazel/generator.go
+++ b/kazel/generator.go
@@ -42,7 +42,7 @@ func (v *Vendorer) walkGenerated() error {
 		return nil
 	}
 	v.managedAttrs = append(v.managedAttrs, "openapi_targets", "vendor_targets")
-	paths, err := v.findOpenAPI(v.root)
+	paths, err := v.findOpenAPI(".")
 	if err != nil {
 		return err
 	}
@@ -52,6 +52,11 @@ func (v *Vendorer) walkGenerated() error {
 // findOpenAPI searches for all packages under root that request OpenAPI. It
 // returns the go import paths. It does not follow symlinks.
 func (v *Vendorer) findOpenAPI(root string) ([]string, error) {
+	for _, r := range v.skippedPaths {
+		if r.Match([]byte(root)) {
+			return nil, nil
+		}
+	}
 	finfos, err := ioutil.ReadDir(root)
 	if err != nil {
 		return nil, err
@@ -77,7 +82,7 @@ func (v *Vendorer) findOpenAPI(root string) ([]string, error) {
 		}
 	}
 	if includeMe {
-		pkg, err := v.ctx.ImportDir(root, 0)
+		pkg, err := v.ctx.ImportDir(filepath.Join(v.root, root), 0)
 		if err != nil {
 			return nil, err
 		}

--- a/kazel/generator.go
+++ b/kazel/generator.go
@@ -53,7 +53,7 @@ func (v *Vendorer) walkGenerated() error {
 // returns the go import paths. It does not follow symlinks.
 func (v *Vendorer) findOpenAPI(root string) ([]string, error) {
 	for _, r := range v.skippedPaths {
-		if r.Match([]byte(root)) {
+		if r.MatchString(root) {
 			return nil, nil
 		}
 	}

--- a/kazel/kazel.go
+++ b/kazel/kazel.go
@@ -228,7 +228,7 @@ func (v *Vendorer) walk(root string, f func(path, ipath string, pkg *build.Packa
 			return filepath.SkipDir
 		}
 		for _, r := range v.skippedPaths {
-			if r.Match([]byte(path)) {
+			if r.MatchString(path) {
 				return filepath.SkipDir
 			}
 		}

--- a/kazel/sourcerer.go
+++ b/kazel/sourcerer.go
@@ -41,7 +41,7 @@ func (v *Vendorer) walkSource(pkgPath string) ([]string, error) {
 	// clean pkgPath since we access v.newRules directly
 	pkgPath = filepath.Clean(pkgPath)
 	for _, r := range v.skippedPaths {
-		if r.Match([]byte(pkgPath)) {
+		if r.MatchString(pkgPath) {
 			return nil, nil
 		}
 	}


### PR DESCRIPTION
Some of the non-Bazel kubernetes build scripts toss Go source under `_output/dockerized/go`; we should not go looking for OpenAPI packages there.

Still testing this (trying to figure out what set of steps actually copies code into `_output/dockerized/go` but I think this will work.

/assign @mikedanese @spxtr 
cc @thockin @nikhita @sttts 