### PR TITLE
Update go_genrule to work for rules_go toolchains changes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,10 +2,12 @@ workspace(name = "io_kubernetes_build")
 
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "f083e0f8bfc4ab3cf58a027ecd4740e1af632212",
+    commit = "7fefcfdf6ad108010bf0dca1b1aaa95e0d2c7ca4",
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 
-go_repositories()
+go_rules_dependencies()
+
+go_register_toolchains()

--- a/defs/bazel_version.bzl
+++ b/defs/bazel_version.bzl
@@ -1,0 +1,32 @@
+# Copied from https://github.com/tensorflow/tensorflow/blob/a6510237f06f03babfbcce1bcfa77f07f0d03c50/tensorflow/workspace.bzl
+
+# Parse the bazel version string from `native.bazel_version`.
+def _parse_bazel_version(bazel_version):
+  # Remove commit from version.
+  version = bazel_version.split(" ", 1)[0]
+
+  # Split into (release, date) parts and only return the release
+  # as a tuple of integers.
+  parts = version.split("-", 1)
+
+  # Turn "release" into a tuple of strings
+  version_tuple = ()
+  for number in parts[0].split("."):
+    version_tuple += (str(number),)
+  return version_tuple
+
+# Check that a specific bazel version is being used.
+def check_version(bazel_version):
+  if "bazel_version" not in dir(native):
+    fail("\nCurrent Bazel version is lower than 0.2.1, expected at least %s\n" %
+         bazel_version)
+  elif not native.bazel_version:
+    print("\nCurrent Bazel is not a release version, cannot check for " +
+          "compatibility.")
+    print("Make sure that you are running at least Bazel %s.\n" % bazel_version)
+  else:
+    current_bazel_version = _parse_bazel_version(native.bazel_version)
+    minimum_bazel_version = _parse_bazel_version(bazel_version)
+    if minimum_bazel_version > current_bazel_version:
+      fail("\nCurrent Bazel version is {}, expected at least {}\n".format(
+          native.bazel_version, bazel_version))

--- a/defs/deb.bzl
+++ b/defs/deb.bzl
@@ -22,7 +22,7 @@ def deb_data(name, data = []):
     deps += [dname]
     pkg_tar(
         name = dname,
-        files = info["files"],
+        srcs = info["files"],
         mode = info["mode"],
         package_dir = info["dir"],
     )

--- a/defs/go.bzl
+++ b/defs/go.bzl
@@ -12,7 +12,7 @@ def _compute_genrule_variables(resolved_srcs, resolved_outs):
   return variables
 
 def _go_sources_aspect_impl(target, ctx):
-  transitive_sources = set(target[GoLibrary].srcs)
+  transitive_sources = depset(target[GoLibrary].srcs)
   for dep in ctx.rule.attr.deps:
     transitive_sources = transitive_sources | dep.transitive_sources
   return struct(transitive_sources = transitive_sources)
@@ -62,7 +62,7 @@ def _compute_genrule_command(ctx):
 
 def _go_genrule_impl(ctx):
   go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
-  all_srcs = set(go_toolchain.data.stdlib)
+  all_srcs = depset(go_toolchain.data.stdlib)
   label_dict = {}
 
   for dep in ctx.attr.go_deps:
@@ -78,7 +78,7 @@ def _go_genrule_impl(ctx):
       command=cmd,
       attribute="cmd",
       expand_locations=True,
-      make_variables=_compute_genrule_variables(all_srcs, set(ctx.outputs.outs)),
+      make_variables=_compute_genrule_variables(all_srcs, depset(ctx.outputs.outs)),
       tools=ctx.attr.tools,
       label_dict=label_dict
   )


### PR DESCRIPTION
Maybe this is the last fix for a while?

I think this works, though I'm not 100% sure. For some reason, bazel is blowing up when I try to build things in kubernetes/kubernetes, but not all targets, and not the ones affected by this change.

Since this locks us into bazel 0.5.4+, I also added a rule (copied from tensorflow) that we can use to enforce bazel versions.

/assign @mikedanese @spxtr 
cc @ianthehat @jayconrod