### PR TITLE
Explicitly set go env, since go_toolchain.env has been removed

### DIFF
--- a/defs/go.bzl
+++ b/defs/go.bzl
@@ -78,7 +78,11 @@ def _go_genrule_impl(ctx):
   ctx.action(
       inputs = list(all_srcs) + resolved_inputs,
       outputs = ctx.outputs.outs,
-      env = ctx.configuration.default_shell_env + go_toolchain.env,
+      env = ctx.configuration.default_shell_env + {
+          "GOROOT": go_toolchain.stdlib.root.path,
+          "GOOS": go_toolchain.stdlib.goos,
+          "GOARCH": go_toolchain.stdlib.goarch,
+          },
       command = argv,
       progress_message = "%s %s" % (ctx.attr.message, ctx),
       mnemonic = "GoGenrule",


### PR DESCRIPTION
https://github.com/bazelbuild/rules_go/pull/922 removed `env` from `go_toolchain`.

There's also a newer `tmp` attribute in `go_toolchain.stdlib`; I'm not sure if we should be using it.

/assign @mikedanese 