### PR TITLE
Fix stdlib dep

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "io_kubernetes_build")
 
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "7fefcfdf6ad108010bf0dca1b1aaa95e0d2c7ca4",
+    commit = "b358831ed503659656daa35a361094a1eee5aa60",
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 

--- a/defs/go.bzl
+++ b/defs/go.bzl
@@ -51,7 +51,7 @@ def _compute_genrule_command(ctx):
 
 def _go_genrule_impl(ctx):
   go_toolchain = ctx.toolchains["@io_bazel_rules_go//go:toolchain"]
-  all_srcs = depset(go_toolchain.data.stdlib)
+  all_srcs = depset(go_toolchain.stdlib)
   label_dict = {}
 
   for dep in ctx.attr.go_deps:


### PR DESCRIPTION
Attempt to fix:
```
W1109 18:31:47.806] ERROR: /workspace/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/sets/BUILD:23:1: in go_genrule rule //vendor/k8s.io/apimachinery/pkg/util/sets:set-gen: 
W1109 18:31:47.807] Traceback (most recent call last):
W1109 18:31:47.807] 	File "/workspace/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/sets/BUILD", line 23
W1109 18:31:47.807] 		go_genrule(name = 'set-gen')
W1109 18:31:47.808] 	File "/root/.cache/bazel/_bazel_root/e9f728bbd90b3fba632eb31b20e1dacd/external/io_kubernetes_build/defs/go.bzl", line 54, in _go_genrule_impl
W1109 18:31:47.808] 		depset(go_toolchain.data.stdlib)
W1109 18:31:47.808] 	File "/root/.cache/bazel/_bazel_root/e9f728bbd90b3fba632eb31b20e1dacd/external/io_kubernetes_build/defs/go.bzl", line 54, in depset
W1109 18:31:47.808] 		go_toolchain.data.stdlib
W1109 18:31:47.809] 'struct' object has no attribute 'stdlib'
W1109 18:31:47.809] Available attributes: crosstool, package_list.
W1109 18:31:48.040] ERROR: Analysis of target '//vendor/k8s.io/kube-aggregator:kube-aggregator' failed; build aborted.
```