### PR TITLE
Add a wrapper macro for pkg_tar which uses the fast build_tar

### DIFF
--- a/defs/deb.bzl
+++ b/defs/deb.bzl
@@ -1,4 +1,5 @@
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar", "pkg_deb")
+load("//defs:pkg.bzl", "pkg_tar")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_deb")
 
 KUBERNETES_AUTHORS = "Kubernetes Authors <kubernetes-dev+release@googlegroups.com>"
 

--- a/defs/pkg.bzl
+++ b/defs/pkg.bzl
@@ -1,0 +1,11 @@
+load(
+    "@bazel_tools//tools/build_defs/pkg:pkg.bzl",
+    _real_pkg_tar = "pkg_tar",
+)
+
+# pkg_tar wraps the official pkg_tar rule with our faster
+# Go-based build_tar binary.
+def pkg_tar(**kwargs):
+    if "build_tar" not in kwargs:
+        kwargs["build_tar"] = "@io_kubernetes_build//tools/build_tar"
+    _real_pkg_tar(**kwargs)


### PR DESCRIPTION
The intent of this is that you can just replace
```python
load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
```
with
```python
load("@io_kubernetes_build//defs:pkg.bzl", "pkg_tar")
```

and magically tarballs will build faster.

(An added benefit is that our implementation of fast `build_tar` doesn't include the leading `./`, so we can finally stop using my fork of bazelbuild/bazel.)

/assign @BenTheElder @mikedanese 