### PR TITLE
Allow specifying a different root file for workspace_binary

### DIFF
--- a/defs/run_in_workspace.bzl
+++ b/defs/run_in_workspace.bzl
@@ -18,7 +18,7 @@
 # Writes out a script which saves the runfiles directory,
 # changes to the workspace root, and then runs a command.
 def _workspace_binary_script_impl(ctx):
-    content = """#!/usr/bin/env bash
+  content = """#!/usr/bin/env bash
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -26,14 +26,22 @@ set -o pipefail
 BASE=$(pwd)
 cd $(dirname $(readlink {root_file}))
 "$BASE/{cmd}" $@
-""".format(cmd=ctx.file.cmd.short_path, root_file=ctx.file.root_file.short_path)
-
-    ctx.actions.write(output=ctx.outputs.executable, content=content, is_executable=True)
-
-    runfiles = ctx.runfiles(
-        files = [ctx.file.cmd, ctx.file.root_file],
-    )
-    return [DefaultInfo(runfiles=runfiles)]
+""".format(
+      cmd = ctx.file.cmd.short_path,
+      root_file = ctx.file.root_file.short_path,
+  )
+  ctx.actions.write(
+      output = ctx.outputs.executable,
+      content = content,
+      is_executable = True,
+  )
+  runfiles = ctx.runfiles(
+      files = [
+          ctx.file.cmd,
+          ctx.file.root_file,
+      ],
+  )
+  return [DefaultInfo(runfiles = runfiles)]
 
 _workspace_binary_script = rule(
     attrs = {
@@ -62,15 +70,20 @@ _workspace_binary_script = rule(
 # )
 #
 # which would allow running dep with bazel run.
-def workspace_binary(name, cmd, visibility=None, root_file="//:WORKSPACE"):
-    script_name = name + "_script"
-    _workspace_binary_script(
-        name = script_name,
-        cmd = cmd,
-        root_file = root_file,
-    )
-    native.sh_binary(
-        name = name,
-        srcs = [":" + script_name],
-        visibility = visibility,
-    )
+def workspace_binary(
+    name,
+    cmd,
+    visibility = None,
+    root_file = "//:WORKSPACE",
+):
+  script_name = name + "_script"
+  _workspace_binary_script(
+      name = script_name,
+      cmd = cmd,
+      root_file = root_file,
+  )
+  native.sh_binary(
+      name = name,
+      srcs = [":" + script_name],
+      visibility = visibility,
+  )

--- a/defs/run_in_workspace.bzl
+++ b/defs/run_in_workspace.bzl
@@ -81,9 +81,11 @@ def workspace_binary(
       name = script_name,
       cmd = cmd,
       root_file = root_file,
+      tags = ["manual"],
   )
   native.sh_binary(
       name = name,
       srcs = [":" + script_name],
       visibility = visibility,
+      tags = ["manual"],
   )

--- a/defs/run_in_workspace.bzl
+++ b/defs/run_in_workspace.bzl
@@ -73,6 +73,7 @@ _workspace_binary_script = rule(
 def workspace_binary(
     name,
     cmd,
+    args = None,
     visibility = None,
     root_file = "//:WORKSPACE",
 ):
@@ -86,6 +87,7 @@ def workspace_binary(
   native.sh_binary(
       name = name,
       srcs = [":" + script_name],
+      args = args,
       visibility = visibility,
       tags = ["manual"],
   )

--- a/defs/run_in_workspace.bzl
+++ b/defs/run_in_workspace.bzl
@@ -24,14 +24,14 @@ set -o nounset
 set -o pipefail
 
 BASE=$(pwd)
-cd $(dirname $(readlink WORKSPACE))
+cd $(dirname $(readlink {root_file}))
 "$BASE/{cmd}" $@
-""".format(cmd=ctx.file.cmd.short_path)
+""".format(cmd=ctx.file.cmd.short_path, root_file=ctx.file.root_file.short_path)
 
     ctx.actions.write(output=ctx.outputs.executable, content=content, is_executable=True)
 
     runfiles = ctx.runfiles(
-        files = [ctx.file.cmd, ctx.file.workspace],
+        files = [ctx.file.cmd, ctx.file.root_file],
     )
     return [DefaultInfo(runfiles=runfiles)]
 
@@ -42,7 +42,7 @@ _workspace_binary_script = rule(
             allow_files = True,
             single_file = True,
         ),
-        "workspace": attr.label(
+        "root_file": attr.label(
             mandatory = True,
             allow_files = True,
             single_file = True,
@@ -62,12 +62,12 @@ _workspace_binary_script = rule(
 # )
 #
 # which would allow running dep with bazel run.
-def workspace_binary(name, cmd, visibility=None):
+def workspace_binary(name, cmd, visibility=None, root_file="//:WORKSPACE"):
     script_name = name + "_script"
     _workspace_binary_script(
-        name=script_name,
-        cmd=cmd,
-        workspace = "//:WORKSPACE",
+        name = script_name,
+        cmd = cmd,
+        root_file = root_file,
     )
     native.sh_binary(
         name = name,


### PR DESCRIPTION
A small enhancement on #60: allow overriding the root file used, in case `WORKSPACE` is weird or missing in some way.

/assign @BenTheElder 