### PR TITLE
Use go_rule() and go_context() for go_genrule()

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "io_kubernetes_build")
 
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "fd3021297ae02a86c32adf2b52fd7fe77d033282",
+    commit = "59327146e5395cd1773bab0107d974f660cc0852",
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 

--- a/defs/go.bzl
+++ b/defs/go.bzl
@@ -1,5 +1,6 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_context")
+load("@io_bazel_rules_go//go:def.bzl", "go_context", "go_rule")
 load("@io_bazel_rules_go//go/private:providers.bzl", "GoArchive")
+load("@io_bazel_rules_go//go/private:rules/prefix.bzl", "go_prefix_default")
 
 go_filetype = ["*.go"]
 
@@ -12,7 +13,7 @@ def _compute_genrule_variables(resolved_srcs, resolved_outs):
     variables["@"] = list(resolved_outs)[0].path
   return variables
 
-def _compute_genrule_command(ctx, go_stdlib):
+def _compute_genrule_command(ctx, go):
   workspace_root = '$$(pwd)'
   if ctx.build_file_path.startswith('external/'):
     # We want GO_WORKSPACE to point at the root directory of the Bazel
@@ -29,20 +30,20 @@ def _compute_genrule_command(ctx, go_stdlib):
 
   cmd = [
       'set -e',
-      'export GOROOT=$$(pwd)/' + go_stdlib.root_file.dirname,
-      'export GOOS=' + go_stdlib.mode.goos,
-      'export GOARCH=' + go_stdlib.mode.goarch,
+      'export GOROOT=$$(pwd)/' + go.root,
+      'export GOOS=' + go.mode.goos,
+      'export GOARCH=' + go.mode.goarch,
       # setup main GOPATH
       'GENRULE_TMPDIR=$$(mktemp -d $${TMPDIR:-/tmp}/bazel_%s_XXXXXXXX)' % ctx.attr.name,
       'export GOPATH=$${GENRULE_TMPDIR}/gopath',
-      'export GO_WORKSPACE=$${GOPATH}/src/' + ctx.attr.go_prefix.go_prefix,
+      'export GO_WORKSPACE=$${GOPATH}/src/' + ctx.attr._go_prefix.go_prefix,
       'mkdir -p $${GO_WORKSPACE%/*}',
       'ln -s %s/ $${GO_WORKSPACE}' % (workspace_root,),
       'if [[ ! -e $${GO_WORKSPACE}/external ]]; then ln -s $$(pwd)/external/ $${GO_WORKSPACE}/; fi',
       'if [[ ! -e $${GO_WORKSPACE}/bazel-out ]]; then ln -s $$(pwd)/bazel-out/ $${GO_WORKSPACE}/; fi',
       # setup genfile GOPATH
       'export GENGOPATH=$${GENRULE_TMPDIR}/gengopath',
-      'export GENGO_WORKSPACE=$${GENGOPATH}/src/' + ctx.attr.go_prefix.go_prefix,
+      'export GENGO_WORKSPACE=$${GENGOPATH}/src/' + ctx.attr._go_prefix.go_prefix,
       'mkdir -p $${GENGO_WORKSPACE%/*}',
       'ln -s $$(pwd)/$(GENDIR) $${GENGO_WORKSPACE}',
       # drop into WORKSPACE
@@ -67,7 +68,7 @@ def _go_genrule_impl(ctx):
     all_srcs += dep.files
     label_dict[dep.label] = dep.files
 
-  cmd = _compute_genrule_command(ctx, go.stdlib)
+  cmd = _compute_genrule_command(ctx, go)
 
   resolved_inputs, argv, runfiles_manifests = ctx.resolve_command(
       command=cmd,
@@ -91,7 +92,8 @@ def _go_genrule_impl(ctx):
 # and thus depend on executing with a valid GOROOT and GOPATH containing
 # some amount transitive go src of dependencies. This go_genrule enables
 # the creation of these sandboxes.
-go_genrule = rule(
+go_genrule = go_rule(
+    _go_genrule_impl,
     attrs = {
         "srcs": attr.label_list(allow_files = True),
         "tools": attr.label_list(
@@ -101,24 +103,10 @@ go_genrule = rule(
         "outs": attr.output_list(mandatory = True),
         "cmd": attr.string(mandatory = True),
         "go_deps": attr.label_list(),
+        "importpath": attr.string(),
         "message": attr.string(),
         "executable": attr.bool(default = False),
-        "_go_context_data": attr.label(default = Label("@io_bazel_rules_go//:go_context_data")),
-        # Next rule copied from bazelbuild/rules_go@a9df110cf04e167b33f10473c7e904d780d921e6
-        # and then modified a bit.
-        # I'm not sure if this is correct anymore.
-        # Also, go_prefix is deprecated, so this is probably going to break in the near future.
-        "go_prefix": attr.label(
-            providers = ["go_prefix"],
-            default = Label(
-                "//:go_prefix",
-                relative_to_caller_repository = True,
-            ),
-            allow_files = False,
-            cfg = "host",
-        ),
+        "_go_prefix": attr.label(default = go_prefix_default),
     },
     output_to_genfiles = True,
-    toolchains = ["@io_bazel_rules_go//go:toolchain"],
-    implementation = _go_genrule_impl,
 )

--- a/defs/go.bzl
+++ b/defs/go.bzl
@@ -2,8 +2,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_context", "go_rule")
 load("@io_bazel_rules_go//go/private:providers.bzl", "GoArchive")
 load("@io_bazel_rules_go//go/private:rules/prefix.bzl", "go_prefix_default")
 
-go_filetype = ["*.go"]
-
 def _compute_genrule_variables(resolved_srcs, resolved_outs):
   variables = {"SRCS": cmd_helper.join_paths(" ", resolved_srcs),
                "OUTS": cmd_helper.join_paths(" ", resolved_outs)}


### PR DESCRIPTION
I'm attempting to update bazelbuild/rules_go on kubernetes/kubernetes, but `go_genrule` is broken once again:
```console
ERROR: [elided]/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/sets/BUILD:23:1: in go_genrule rule //vendor/k8s.io/apimachinery/pkg/util/sets:set-gen:
Traceback (most recent call last):
        File "[elided]/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/sets/BUILD", line 23
                go_genrule(name = 'set-gen')
        File "[elided]/.cache/bazel/_bazel_jgrafton/75e5737b0f848bf1b7c3ab3303c8bf72/external/io_kubernetes_build/defs/go.bzl", line 59, in _go_genrule_impl
                depset(go.stdlib.files)
        File "[elided]/.cache/bazel/_bazel_jgrafton/75e5737b0f848bf1b7c3ab3303c8bf72/external/io_kubernetes_build/defs/go.bzl", line 59, in depset
                go.stdlib.files
object of type 'NoneType' has no field 'files'
ERROR: Analysis of target '//staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest:go_default_library' failed; build aborted: Analysis of target '//vendor/k8s.io/apimachinery/pkg/util/sets:set-gen' failed; build aborted
```

This appears to be at least partially due to https://github.com/bazelbuild/rules_go/pull/1295.

Looking at the changes, I've inferred that we probably need to depend on the new `@io_bazel_rules_go//:stdlib` label, which I've done here.

Everything builds, so this is probably the correct fix?
/shrug
/assign @BenTheElder @mikedanese 
/cc @ianthehat

/hold
since this will want to be sequenced with the rules_go bump in kubernetes/kubernetes
which also requires a gazelle bump
which first requires https://github.com/bazelbuild/bazel-gazelle/pull/125