### PR TITLE
Use a smarter regexp for openapi tag detection

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "io_kubernetes_build")
 
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "59327146e5395cd1773bab0107d974f660cc0852",
+    commit = "f676870c5caf8df559a51e7aa005d2ece148a03b",
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 

--- a/kazel/generator.go
+++ b/kazel/generator.go
@@ -17,19 +17,23 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 )
 
 const (
-	openAPIGenTag = "// +k8s:openapi-gen"
+	openAPITagName = "openapi-gen"
+	staging        = "staging/src/"
+)
 
-	staging = "staging/src/"
+var (
+	// Generator tags are specified using the format "// +k8s:name=value"
+	genTagRe = regexp.MustCompile(`//\s*\+k8s:([^\s=]+)(?:=(\S+))\s*\n`)
 )
 
 // walkGenerated updates the rule for kubernetes' OpenAPI generated file.
@@ -75,8 +79,12 @@ func (v *Vendorer) findOpenAPI(root string) ([]string, error) {
 			if err != nil {
 				return nil, err
 			}
-			if bytes.Contains(b, []byte(openAPIGenTag)) {
-				includeMe = true
+			matches := genTagRe.FindAllSubmatch(b, -1)
+			for _, m := range matches {
+				if len(m) >= 2 && string(m[1]) == openAPITagName {
+					includeMe = true
+					break
+				}
 			}
 		}
 	}


### PR DESCRIPTION
I tried a few other options:
* using `go/parser` to scan only comments
* using regexp's multiline flag to try to better detect real comments

but both of these were significantly slower than this approach, taking 5-7s to run. 

For comparison, both this implementation and the existing, buggy `Contains()` implementation take around 1.5s. (Using the regex seems to be about .1-.2s slower, but that is probably allowable.)

I've also this implementation a bit more generic in preparation for kazel learning how to handle additional codegen tags.

Fixes #66.

/assign @mikedanese 