### PR TITLE
Don't check for OpenAPI tags in skipped paths

### DIFF
--- a/kazel/generator.go
+++ b/kazel/generator.go
@@ -56,7 +56,7 @@ func (v *Vendorer) walkGenerated() error {
 // returns the go import paths. It does not follow symlinks.
 func (v *Vendorer) findOpenAPI(root string) ([]string, error) {
 	for _, r := range v.skippedPaths {
-		if r.MatchString(root) {
+		if r.MatchString(filepath.Base(root)) {
 			return nil, nil
 		}
 	}


### PR DESCRIPTION
Fixes #68

We were checking `SkippedPaths` regex rules against the whole path. IMO this should be just on the base. Kubernetes currently uses `^_.*` for `SkippedPaths`, which doesn't work as desired.