### PR TITLE
Linters need more time to run

### DIFF
--- a/verify/go-tools/verify-gometalinter.sh
+++ b/verify/go-tools/verify-gometalinter.sh
@@ -17,7 +17,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-gometalinter --deadline=50s --vendor \
+gometalinter --deadline=180s --vendor \
     --cyclo-over=50 --dupl-threshold=100 \
     --exclude=".*should not use dot imports \(golint\)$" \
     --disable-all \


### PR DESCRIPTION
gometalinter needs more time in Kubernetes Incubator Project ExternalDNS. I would suggest to bump it up a bit.

Currently TravisCI won't pass the tests correctly due to the deadline of 50s.

Thoughts?