### PR TITLE
Add SkippedOpenAPIGenPaths configuration

### DIFF
--- a/kazel/config.go
+++ b/kazel/config.go
@@ -28,6 +28,9 @@ type Cfg struct {
 	SrcDirs []string
 	// regexps that match packages to skip
 	SkippedPaths []string
+	// regexps that match packages to skip for K8SOpenAPIGen.
+	// note that this skips anything matched by SkippedPaths as well.
+	SkippedOpenAPIGenPaths []string
 	// whether to add "pkg-srcs" and "all-srcs" filegroups
 	// note that this operates on the entire tree (not just SrcsDirs) but skips anything matching SkippedPaths
 	AddSourcesRules bool

--- a/kazel/generator.go
+++ b/kazel/generator.go
@@ -55,7 +55,7 @@ func (v *Vendorer) walkGenerated() error {
 // findOpenAPI searches for all packages under root that request OpenAPI. It
 // returns the go import paths. It does not follow symlinks.
 func (v *Vendorer) findOpenAPI(root string) ([]string, error) {
-	for _, r := range v.skippedPaths {
+	for _, r := range v.skippedOpenAPIPaths {
 		if r.MatchString(root) {
 			return nil, nil
 		}


### PR DESCRIPTION
Typical use-case for this additional configuration is the following

User has a couple of packages:

- `pkg/apis/foo/v1beta1` with `+k8s:openapi-gen=true`
- `pkg/apis/_test/v1` with `+k8s:openapi-gen=true`
- `third_party`
- `pkg/server`

And wants the generate `BUILD` files for everything except `third_party` and `OpenAPI` definitions only for `pkg/apis/foo/v1beta1` while ignoring `pkg/apis/_test/v1`.

```json
{
	"GoPrefix": "foo.corp/baz",
	"SkippedPaths": [
		"^third_party/.*"
	],
	"SkippedOpenAPIGenPaths": [
		"^pkg/apis/_test/.*"
	],
	"AddSourcesRules": true,
	"K8sOpenAPIGen": true
}
```

This is a prerequisite for kubernetes/kubernetes#65440