### PR TITLE
Rework k8s codegen tag support in kazel

### DIFF
--- a/kazel/BUILD.bazel
+++ b/kazel/BUILD.bazel
@@ -6,6 +6,7 @@ load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_binary",
     "go_library",
+    "go_test",
 )
 
 go_binary(
@@ -29,4 +30,14 @@ go_library(
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "generator_test.go",
+        "kazel_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = ["//vendor/github.com/bazelbuild/buildtools/build:go_default_library"],
 )

--- a/kazel/config.go
+++ b/kazel/config.go
@@ -28,19 +28,25 @@ type Cfg struct {
 	SrcDirs []string
 	// regexps that match packages to skip
 	SkippedPaths []string
-	// regexps that match packages to skip for K8SOpenAPIGen.
+	// regexps that match packages to skip for k8s codegen.
 	// note that this skips anything matched by SkippedPaths as well.
-	SkippedOpenAPIGenPaths []string
+	SkippedK8sCodegenPaths []string
 	// whether to add "pkg-srcs" and "all-srcs" filegroups
 	// note that this operates on the entire tree (not just SrcsDirs) but skips anything matching SkippedPaths
 	AddSourcesRules bool
 	// whether to have multiple build files in vendor/ or just one.
 	VendorMultipleBuildFiles bool
-	// whether to manage kubernetes' pkg/generated/openapi.
-	K8sOpenAPIGen bool
 	// Whether to manage the upstream Go rules provided by bazelbuild/rules_go.
 	// If using gazelle, set this to false (or omit).
 	ManageGoRules bool
+	// If defined, metadata parsed from "+k8s:" codegen build tags will be saved into this file.
+	K8sCodegenBzlFile string
+	// If defined, contains the boilerplate text to be included in the header of the generated bzl file.
+	K8sCodegenBoilerplateFile string
+	// Which tags to include in the codegen bzl file.
+	// Include only the name of the tag.
+	// For example, to include +k8s:foo=bar, list "foo" here.
+	K8sCodegenTags []string
 }
 
 // ReadCfg reads and unmarshals the specified json file into a Cfg struct.

--- a/kazel/generator_test.go
+++ b/kazel/generator_test.go
@@ -23,8 +23,9 @@ import (
 
 func TestExtractTags(t *testing.T) {
 	requestedTags := map[string]bool{
-		"foo-gen": true,
-		"baz-gen": true,
+		"foo-gen":                    true,
+		"baz-gen":                    true,
+		"quux-gen:with-extra@things": true,
 	}
 	var testCases = []struct {
 		src  string
@@ -37,6 +38,14 @@ func TestExtractTags(t *testing.T) {
 		{
 			src:  "// +k8s:bar-gen=a,b\n",
 			want: map[string][]string{},
+		},
+		{
+			src:  "// +k8s:quux-gen=true\n",
+			want: map[string][]string{},
+		},
+		{
+			src:  "// +k8s:quux-gen:with-extra@things=123\n",
+			want: map[string][]string{"quux-gen:with-extra@things": {"123"}},
 		},
 		{
 			src: `/*
@@ -75,7 +84,7 @@ import "some package"
 }
 
 func TestFlattened(t *testing.T) {
-	m := generatorTagsValuesPkgsMap{
+	m := generatorTagsMap{
 		"foo-gen": {
 			"a": {
 				"pkg/one": true,

--- a/kazel/generator_test.go
+++ b/kazel/generator_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractTags(t *testing.T) {
+	requestedTags := map[string]bool{
+		"foo-gen": true,
+		"baz-gen": true,
+	}
+	var testCases = []struct {
+		src  string
+		want map[string][]string
+	}{
+		{
+			src:  "// +k8s:foo-gen=a,b\n",
+			want: map[string][]string{"foo-gen": {"a", "b"}},
+		},
+		{
+			src:  "// +k8s:bar-gen=a,b\n",
+			want: map[string][]string{},
+		},
+		{
+			src: `/*
+This is a header.
+*/
+// +k8s:foo-gen=first
+// +k8s:bar-gen=true
+// +build linux
+
+// +k8s:baz-gen=1,2,a
+// +k8s:baz-gen=b
+
+// k8s:foo-gen=not-this-one
+// commenting out this one too  +k8s:foo-gen=disabled
+// +k8s:foo-gen=ignore this one too
+
+// Let's repeat one!
+// +k8s:baz-gen=b
+// +k8s:foo-gen=last
+
+import "some package"
+`,
+			want: map[string][]string{
+				"foo-gen": {"first", "last"},
+				"baz-gen": {"1", "2", "a", "b", "b"},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		result := extractTags([]byte(testCase.src), requestedTags)
+		if !reflect.DeepEqual(result, testCase.want) {
+			t.Errorf("extractTags(%v) = %v; want %v", testCase.src, result, testCase.want)
+		}
+	}
+}
+
+func TestFlattened(t *testing.T) {
+	m := generatorTagsValuesPkgsMap{
+		"foo-gen": {
+			"a": {
+				"pkg/one": true,
+				"pkg/two": true,
+			},
+		},
+		"bar-gen": {
+			"true": {
+				"pkg/one":   true,
+				"pkg/three": true,
+				// also test sorting - this should end up at the front of the slice
+				"a/pkg": true,
+			},
+			"false": {
+				"pkg/one": true,
+			},
+		},
+	}
+
+	want := map[string]map[string][]string{
+		"foo-gen": {
+			"a": {"pkg/one", "pkg/two"},
+		},
+		"bar-gen": {
+			"true":  {"a/pkg", "pkg/one", "pkg/three"},
+			"false": {"pkg/one"},
+		},
+	}
+
+	result := flattened(m)
+	if !reflect.DeepEqual(result, want) {
+		t.Errorf("flattened(%v) = %v; want %v", m, result, want)
+	}
+
+}

--- a/kazel/kazel.go
+++ b/kazel/kazel.go
@@ -73,7 +73,8 @@ func main() {
 			klog.Fatalf("err walking repo: %v", err)
 		}
 	}
-	if err = v.walkGenerated(); err != nil {
+	wroteGenerated := false
+	if wroteGenerated, err = v.walkGenerated(); err != nil {
 		klog.Fatalf("err walking generated: %v", err)
 	}
 	if _, err = v.walkSource("."); err != nil {
@@ -83,6 +84,9 @@ func main() {
 	if written, err = v.reconcileAllRules(); err != nil {
 		klog.Fatalf("err reconciling rules: %v", err)
 	}
+	if wroteGenerated {
+		written++
+	}
 	if *validate && written > 0 {
 		fmt.Fprintf(os.Stderr, "\n%d BUILD files not up-to-date.\n", written)
 		os.Exit(1)
@@ -91,15 +95,15 @@ func main() {
 
 // Vendorer collects context, configuration, and cache while walking the tree.
 type Vendorer struct {
-	ctx                 *build.Context
-	icache              map[icacheKey]icacheVal
-	skippedPaths        []*regexp.Regexp
-	skippedOpenAPIPaths []*regexp.Regexp
-	dryRun              bool
-	root                string
-	cfg                 *Cfg
-	newRules            map[string][]*bzl.Rule // package path -> list of rules to add or update
-	managedAttrs        []string
+	ctx                    *build.Context
+	icache                 map[icacheKey]icacheVal
+	skippedPaths           []*regexp.Regexp
+	skippedK8sCodegenPaths []*regexp.Regexp
+	dryRun                 bool
+	root                   string
+	cfg                    *Cfg
+	newRules               map[string][]*bzl.Rule // package path -> list of rules to add or update
+	managedAttrs           []string
 }
 
 func newVendorer(root, cfgPath string, dryRun bool) (*Vendorer, error) {
@@ -137,11 +141,11 @@ func newVendorer(root, cfgPath string, dryRun bool) (*Vendorer, error) {
 	sp = append(builtIn, sp...)
 	v.skippedPaths = sp
 
-	sop, err := compileSkippedPaths(cfg.SkippedOpenAPIGenPaths)
+	sop, err := compileSkippedPaths(cfg.SkippedK8sCodegenPaths)
 	if err != nil {
 		return nil, err
 	}
-	v.skippedOpenAPIPaths = append(sop, sp...)
+	v.skippedK8sCodegenPaths = append(sop, sp...)
 
 	return &v, nil
 
@@ -284,7 +288,6 @@ const (
 	RuleTypeGoXTest
 	RuleTypeCGoGenrule
 	RuleTypeFileGroup
-	RuleTypeOpenAPILibrary
 )
 
 // RuleKind converts a value of the RuleType* enum into the BUILD string.
@@ -302,8 +305,6 @@ func (rt ruleType) RuleKind() string {
 		return "cgo_genrule"
 	case RuleTypeFileGroup:
 		return "filegroup"
-	case RuleTypeOpenAPILibrary:
-		return "openapi_library"
 	}
 	panic("unreachable")
 }
@@ -530,6 +531,42 @@ func (l Label) String() string {
 	return fmt.Sprintf("//%v:%v", l.pkg, l.tag)
 }
 
+// addCommentBefore adds a whole-line comment before the provided Expr.
+func addCommentBefore(e bzl.Expr, comment string) {
+	c := e.Comment()
+	c.Before = append(c.Before, bzl.Comment{Token: fmt.Sprintf("# %s", comment)})
+}
+
+// varExpr creates a variable expression of the form "name = expr".
+// v will be converted into an appropriate Expr using asExpr.
+// The optional description will be included as a comment before the expression.
+func varExpr(name, desc string, v interface{}) bzl.Expr {
+	e := &bzl.BinaryExpr{
+		X:  &bzl.LiteralExpr{Token: name},
+		Op: "=",
+		Y:  asExpr(v),
+	}
+	if desc != "" {
+		addCommentBefore(e, desc)
+	}
+	return e
+}
+
+// rvSliceLessFunc returns a function that can be used with sort.Slice() or sort.SliceStable()
+// to sort a slice of reflect.Values.
+// It sorts ints and floats as their native kinds, and everything else as a string.
+func rvSliceLessFunc(k reflect.Kind, vs []reflect.Value) func(int, int) bool {
+	switch k {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return func(i, j int) bool { return vs[i].Int() < vs[j].Int() }
+	case reflect.Float32, reflect.Float64:
+		return func(i, j int) bool { return vs[i].Float() < vs[j].Float() }
+	default:
+		return func(i, j int) bool { return vs[i].String() < vs[j].String() }
+	}
+}
+
 func asExpr(e interface{}) bzl.Expr {
 	rv := reflect.ValueOf(e)
 	switch rv.Kind() {
@@ -546,8 +583,19 @@ func asExpr(e interface{}) bzl.Expr {
 			list = append(list, asExpr(rv.Index(i).Interface()))
 		}
 		return &bzl.ListExpr{List: list}
+	case reflect.Map:
+		var list []bzl.Expr
+		keys := rv.MapKeys()
+		sort.SliceStable(keys, rvSliceLessFunc(rv.Type().Key().Kind(), keys))
+		for _, key := range keys {
+			list = append(list, &bzl.KeyValueExpr{
+				Key:   asExpr(key.Interface()),
+				Value: asExpr(rv.MapIndex(key).Interface()),
+			})
+		}
+		return &bzl.DictExpr{List: list}
 	default:
-		klog.Fatalf("Uh oh")
+		klog.Fatalf("unhandled kind: %q for value: %q", rv.Kind(), rv)
 		return nil
 	}
 }
@@ -639,7 +687,7 @@ func ReconcileRules(pkgPath string, rules []*bzl.Rule, managedAttrs []string, dr
 			reconcileLoad(f, rules)
 		}
 		writeRules(f, rules)
-		return writeFile(path, f, false, dryRun)
+		return writeFile(path, f, nil, false, dryRun)
 	} else if err != nil {
 		return false, err
 	}
@@ -690,7 +738,7 @@ func ReconcileRules(pkgPath string, rules []*bzl.Rule, managedAttrs []string, dr
 		reconcileLoad(f, f.Rules(""))
 	}
 
-	return writeFile(path, f, true, dryRun)
+	return writeFile(path, f, nil, true, dryRun)
 }
 
 func reconcileLoad(f *bzl.File, rules []*bzl.Rule) {
@@ -746,10 +794,12 @@ func RuleIsManaged(r *bzl.Rule, manageGoRules bool) bool {
 	return automanaged
 }
 
-func writeFile(path string, f *bzl.File, exists, dryRun bool) (bool, error) {
+func writeFile(path string, f *bzl.File, boilerplate []byte, exists, dryRun bool) (bool, error) {
 	var info bzl.RewriteInfo
 	bzl.Rewrite(f, &info)
-	out := bzl.Format(f)
+	var out []byte
+	out = append(out, boilerplate...)
+	out = append(out, bzl.Format(f)...)
 	if exists {
 		orig, err := ioutil.ReadFile(path)
 		if err != nil {
@@ -775,13 +825,13 @@ func writeFile(path string, f *bzl.File, exists, dryRun bool) (bool, error) {
 
 func context() *build.Context {
 	return &build.Context{
-		GOARCH:      "amd64",
-		GOOS:        "linux",
+		GOARCH:      build.Default.GOARCH,
+		GOOS:        build.Default.GOOS,
 		GOROOT:      build.Default.GOROOT,
 		GOPATH:      build.Default.GOPATH,
-		ReleaseTags: []string{"go1.1", "go1.2", "go1.3", "go1.4", "go1.5", "go1.6", "go1.7", "go1.8"},
 		Compiler:    runtime.Compiler,
 		CgoEnabled:  true,
+		UseAllFiles: true,
 	}
 }
 

--- a/kazel/kazel_test.go
+++ b/kazel/kazel_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/buildtools/build"
+)
+
+func TestAsExpr(t *testing.T) {
+	var testCases = []struct {
+		expr interface{}
+		want string
+	}{
+		{42, "42"},
+		{2.71828, "2.71828"},
+		{2.718281828459045, "2.718281828459045"},
+		{"a string", `"a string"`},
+		// values should stay in specified order
+		{[]int{4, 7, 2, 9, 21}, `[
+    4,
+    7,
+    2,
+    9,
+    21,
+]`},
+		// keys should get sorted
+		{map[int]string{1: "foo", 5: "baz", 3: "bar"}, `{
+    1: "foo",
+    3: "bar",
+    5: "baz",
+}`},
+		// keys true and false should be sorted by their string representation
+		{
+			map[bool]map[string][]float64{
+				true:  {"b": {2, 2.2}, "a": {1, 1.1, 1.11}},
+				false: {"": {}},
+			},
+			`{
+    false: {"": []},
+    true: {
+        "a": [
+            1,
+            1.1,
+            1.11,
+        ],
+        "b": [
+            2,
+            2.2,
+        ],
+    },
+}`},
+	}
+
+	for _, testCase := range testCases {
+		result := build.FormatString(asExpr(testCase.expr))
+		if result != testCase.want {
+			t.Errorf("asExpr(%v) = %v; want %v", testCase.expr, result, testCase.want)
+		}
+	}
+}


### PR DESCRIPTION
Rather than searching for the `openapi-gen` tag and managing a special `openapi_library` rule, save relevant tag information in a `.bzl` file, which can then be parsed by a Skylark macro in a genrule.

There are three configuration knobs:
* `K8sCodegenBzlFile`: what `.bzl` file to generate
* `K8sCodegenBoilerplateFile`: the necessary boilerplate text to include in the generated file
* `K8sCodegenTags`: a list of tags to include in the generated bzl file

For example, on k/k, if I use the following `.kazelcfg.json`:
```json
{
        "GoPrefix": "k8s.io/kubernetes",
        "SkippedPaths": [
                "^_.*",
                "/_",
                "^third_party/etcd.*"
        ],
        "AddSourcesRules": true,
        "K8sCodegenBzlFile": "build/generated.bzl",
        "K8sCodegenBoilerplateFile": "hack/boilerplate/boilerplate.generatebzl.txt",
        "K8sCodegenTags": [
                "openapi-gen"
        ]
}
```
then running this new kazel binary produces the following `build/generated.bzl`:
```python
# Copyright The Kubernetes Authors.
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

# #################################################
# # # # # # # # # # # # # # # # # # # # # # # # # #
# This file is autogenerated by kazel. DO NOT EDIT.
# # # # # # # # # # # # # # # # # # # # # # # # # #
# #################################################
#
# The go prefix passed to kazel
go_prefix = "k8s.io/kubernetes"

# The list of codegen tags kazel is configured to find
kazel_configured_tags = ["openapi-gen"]

# tags_values_pkgs is a dictionary mapping {k8s build tag: {tag value: [pkgs including that tag:value]}}
tags_values_pkgs = {"openapi-gen": {
    "false": [
        "staging/src/k8s.io/api/admission/v1beta1",
        "staging/src/k8s.io/api/core/v1",
        "staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1",
        "staging/src/k8s.io/apiserver/pkg/apis/example/v1",
        "staging/src/k8s.io/apiserver/pkg/apis/example2/v1",
    ],
    "true": [
        "cmd/cloud-controller-manager/app/apis/config/v1alpha1",
        "pkg/apis/abac/v0",
        "pkg/apis/abac/v1beta1",
        "pkg/apis/auditregistration",
        "pkg/version",
        "staging/src/k8s.io/api/admissionregistration/v1alpha1",
        "staging/src/k8s.io/api/admissionregistration/v1beta1",
        "staging/src/k8s.io/api/apps/v1",
        "staging/src/k8s.io/api/apps/v1beta1",
        "staging/src/k8s.io/api/apps/v1beta2",
        "staging/src/k8s.io/api/auditregistration/v1alpha1",
...
        "staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1",
        "staging/src/k8s.io/kube-controller-manager/config/v1alpha1",
        "staging/src/k8s.io/kube-proxy/config/v1alpha1",
        "staging/src/k8s.io/kube-scheduler/config/v1alpha1",
        "staging/src/k8s.io/kubelet/config/v1beta1",
        "staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1",
        "staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta2",
        "staging/src/k8s.io/metrics/pkg/apis/external_metrics/v1beta1",
        "staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1",
        "staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1",
    ],
}}

```

This can be combined with the openapi-specific changes in https://github.com/kubernetes/kubernetes/pull/65501, and would be extensible to other code generators in the future.

/assign @fejta @BenTheElder 