### PR TITLE
go_genrule: include Go SDK srcs in dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,8 +2,8 @@ workspace(name = "io_kubernetes_build")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "c1f52b8789218bb1542ed362c4f7de7052abcf254d865d96fb7ba6d44bc15ee3",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.12.0/rules_go-0.12.0.tar.gz",
+    sha256 = "5f3b0304cdf0c505ec9e5b3c4fc4a87b5ca21b13d8ecc780c97df3d1809b9ce6",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.15.1/rules_go-0.15.1.tar.gz",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")

--- a/defs/go.bzl
+++ b/defs/go.bzl
@@ -28,7 +28,7 @@ def _compute_genrule_variables(resolved_srcs, resolved_outs):
 def _go_genrule_impl(ctx):
     go = go_context(ctx)
 
-    all_srcs = depset(go.stdlib.files)
+    all_srcs = depset(go.stdlib.libs + go.sdk.srcs + [go.sdk.go])
     label_dict = {}
     go_paths = []
 
@@ -53,7 +53,10 @@ def _go_genrule_impl(ctx):
 
     cmd = [
         "set -e",
-        "export GOPATH=" + ctx.configuration.host_path_separator.join(["$$(pwd)/" + p for p in go_paths]),
+        "export GO_GENRULE_EXECROOT=$$(pwd)",
+        # Set GOPATH and GOROOT to absolute paths so that commands can chdir without issue
+        "export GOPATH=" + ctx.configuration.host_path_separator.join(["$$GO_GENRULE_EXECROOT/" + p for p in go_paths]),
+        "export GOROOT=$$GO_GENRULE_EXECROOT/" + go.root,
         ctx.attr.cmd.strip(" \t\n\r"),
     ]
     resolved_inputs, argv, runfiles_manifests = ctx.resolve_command(


### PR DESCRIPTION
Code generators like openapi-gen seem to need full access to the Go stdlib sources, not just the compiled libraries.

Additionally, the go rules set $GOROOT using a relative path, which causes issues when we chdir.

Fix both of these issues, and expose a standard $GO_GENRULE_EXECROOT environment variable too, to make it easier to write these genrules correctly.

This fixes the issues described in https://github.com/kubernetes/kubernetes/pull/65501#issuecomment-400761696.

This is a redo of #76, where github got confused.

/assign @BenTheElder @fejta