### PR TITLE
buildtar: Always make package directory

### DIFF
--- a/tools/build_tar/buildtar.go
+++ b/tools/build_tar/buildtar.go
@@ -276,6 +276,13 @@ func (f *tarFile) addTar(toAdd string) error {
 	root := ""
 	if f.directory != "/" {
 		root = f.directory
+		header := tar.Header{
+			Name:     root,
+			Typeflag: tar.TypeDir,
+		}
+		if err := f.makeDirs(header); err != nil {
+			return err
+		}
 	}
 
 	var r io.Reader


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/64018
allowing kubernetes-cni.deb to install correctly.