### PR TITLE
go_genrule: set GOROOT to the downloaded SDK rather than compiled stdlib

### DIFF
--- a/defs/go.bzl
+++ b/defs/go.bzl
@@ -29,7 +29,7 @@ def _compute_genrule_variables(resolved_srcs, resolved_outs, dep_import_paths):
 def _go_genrule_impl(ctx):
     go = go_context(ctx)
 
-    all_srcs = depset(go.stdlib.libs + go.sdk.srcs + go.sdk.tools + [go.sdk.go])
+    all_srcs = depset(go.sdk.libs + go.sdk.srcs + go.sdk.tools + [go.sdk.go])
     label_dict = {}
     go_paths = []
 
@@ -61,8 +61,8 @@ def _go_genrule_impl(ctx):
         "export GO_GENRULE_EXECROOT=$$(pwd)",
         # Set GOPATH, GOROOT, and PATH to absolute paths so that commands can chdir without issue
         "export GOPATH=" + ctx.configuration.host_path_separator.join(["$$GO_GENRULE_EXECROOT/" + p for p in go_paths]),
-        "export GOROOT=$$GO_GENRULE_EXECROOT/" + go.root,
-        "export PATH=$$GO_GENRULE_EXECROOT/" + go.root + "/bin:$$PATH",
+        "export GOROOT=$$GO_GENRULE_EXECROOT/" + go.sdk.root_file.dirname,
+        "export PATH=$$GO_GENRULE_EXECROOT/" + go.sdk.root_file.dirname + "/bin:$$PATH",
         ctx.attr.cmd.strip(" \t\n\r"),
     ]
     resolved_inputs, argv, runfiles_manifests = ctx.resolve_command(


### PR DESCRIPTION
This is a potential fix for #86.

I've tested it with @cblecker's patch bumping to go1.11, and have confirmed that the `zz_generated.openapi.go` file built under bazel (both with and without the race detector feature) matches the file built under `make generated_files`.

I think for `go_genrule` it probably makes more sense to point to the SDK rather than the compiled library, since we don't handle any compilation features anyway.

cc @jayconrod @chrismcbride if they have any thoughts.