### PR TITLE
Adjust gometalinter's by using an env

### DIFF
--- a/verify/go-tools/verify-gometalinter.sh
+++ b/verify/go-tools/verify-gometalinter.sh
@@ -17,7 +17,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-gometalinter --deadline=180s --vendor \
+gometalinter --deadline="${GOMETALINTER_DEADLINE:-180s}" --vendor \
     --cyclo-over=50 --dupl-threshold=100 \
     --exclude=".*should not use dot imports \(golint\)$" \
     --disable-all \


### PR DESCRIPTION
[ExternalDNS](https://github.com/kubernetes-incubator/external-dns) still uses repo-infra and it's underlying gometalinter tests. We already bumped the `gometalinter` deadline timeout but it seems it's not enough anymore. Currently all PR's are failing due to timeout exceeds for gometalinter.

We're guessing that TravisCI instances are not that big or have only a spare capacity to run such tests.

I would highly appreciate if we could merge this PR 😄🤞. 
 
This would allow us to use an env var in Travis, so that we can adjust the timeout when we need it.

Signed-off-by: Nick Jüttner <nick@zalando.de>