### PR TITLE
kazel: remove support for managing Go rules

### DIFF
--- a/kazel/BUILD.bazel
+++ b/kazel/BUILD.bazel
@@ -12,7 +12,6 @@ load(
 go_binary(
     name = "kazel",
     embed = [":go_default_library"],
-    tags = ["automanaged"],
 )
 
 go_library(
@@ -25,7 +24,6 @@ go_library(
         "sourcerer.go",
     ],
     importpath = "k8s.io/repo-infra/kazel",
-    tags = ["automanaged"],
     deps = [
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/kazel/kazel.go
+++ b/kazel/kazel.go
@@ -20,15 +20,12 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"go/build"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"runtime"
 	"sort"
-	"strings"
 
 	bzl "github.com/bazelbuild/buildtools/build"
 
@@ -36,7 +33,6 @@ import (
 )
 
 const (
-	vendorPath     = "vendor/"
 	automanagedTag = "automanaged"
 )
 
@@ -64,15 +60,10 @@ func main() {
 	if err = os.Chdir(v.root); err != nil {
 		klog.Fatalf("cannot chdir into root %q: %v", v.root, err)
 	}
-
 	if v.cfg.ManageGoRules {
-		if err = v.walkVendor(); err != nil {
-			klog.Fatalf("err walking vendor: %v", err)
-		}
-		if err = v.walkRepo(); err != nil {
-			klog.Fatalf("err walking repo: %v", err)
-		}
+		klog.Fatalf("kazel no longer supports managing Go rules")
 	}
+
 	wroteGenerated := false
 	if wroteGenerated, err = v.walkGenerated(); err != nil {
 		klog.Fatalf("err walking generated: %v", err)
@@ -95,15 +86,13 @@ func main() {
 
 // Vendorer collects context, configuration, and cache while walking the tree.
 type Vendorer struct {
-	ctx                    *build.Context
-	icache                 map[icacheKey]icacheVal
 	skippedPaths           []*regexp.Regexp
 	skippedK8sCodegenPaths []*regexp.Regexp
 	dryRun                 bool
 	root                   string
 	cfg                    *Cfg
 	newRules               map[string][]*bzl.Rule // package path -> list of rules to add or update
-	managedAttrs           []string
+	managedAttrs           []string               // which rule attributes kazel will overwrite
 }
 
 func newVendorer(root, cfgPath string, dryRun bool) (*Vendorer, error) {
@@ -120,13 +109,11 @@ func newVendorer(root, cfgPath string, dryRun bool) (*Vendorer, error) {
 	}
 
 	v := Vendorer{
-		ctx:          context(),
 		dryRun:       dryRun,
 		root:         absRoot,
-		icache:       map[icacheKey]icacheVal{},
 		cfg:          cfg,
 		newRules:     make(map[string][]*bzl.Rule),
-		managedAttrs: []string{"srcs", "deps", "library"},
+		managedAttrs: []string{"srcs"},
 	}
 
 	builtIn, err := compileSkippedPaths([]string{"^\\.git", "^bazel-*"})
@@ -151,340 +138,15 @@ func newVendorer(root, cfgPath string, dryRun bool) (*Vendorer, error) {
 
 }
 
-type icacheKey struct {
-	path, srcDir string
-}
-
-type icacheVal struct {
-	pkg *build.Package
-	err error
-}
-
-func (v *Vendorer) importPkg(path string, srcDir string) (*build.Package, error) {
-	k := icacheKey{path: path, srcDir: srcDir}
-	if val, ok := v.icache[k]; ok {
-		return val.pkg, val.err
-	}
-
-	// cache miss
-	pkg, err := v.ctx.Import(path, srcDir, build.ImportComment)
-	v.icache[k] = icacheVal{pkg: pkg, err: err}
-	return pkg, err
-}
-
-func writeHeaders(file *bzl.File) {
-	pkgRule := bzl.Rule{
-		Call: &bzl.CallExpr{
-			X: &bzl.LiteralExpr{Token: "package"},
-		},
-	}
-	pkgRule.SetAttr("default_visibility", asExpr([]string{"//visibility:public"}))
-
-	file.Stmt = append(file.Stmt,
-		[]bzl.Expr{
-			pkgRule.Call,
-			&bzl.CallExpr{
-				X: &bzl.LiteralExpr{Token: "load"},
-				List: asExpr([]string{
-					"@io_bazel_rules_go//go:def.bzl",
-				}).(*bzl.ListExpr).List,
-			},
-		}...,
-	)
-}
-
 func writeRules(file *bzl.File, rules []*bzl.Rule) {
 	for _, rule := range rules {
 		file.Stmt = append(file.Stmt, rule.Call)
 	}
 }
 
-func (v *Vendorer) resolve(ipath string) Label {
-	if ipath == v.cfg.GoPrefix {
-		return Label{
-			tag: "go_default_library",
-		}
-	} else if strings.HasPrefix(ipath, v.cfg.GoPrefix) {
-		return Label{
-			pkg: strings.TrimPrefix(ipath, v.cfg.GoPrefix+"/"),
-			tag: "go_default_library",
-		}
-	}
-	if v.cfg.VendorMultipleBuildFiles {
-		return Label{
-			pkg: "vendor/" + ipath,
-			tag: "go_default_library",
-		}
-	}
-	return Label{
-		pkg: "vendor",
-		tag: ipath,
-	}
-}
-
-func (v *Vendorer) walk(root string, f func(path, ipath string, pkg *build.Package) error) error {
-	skipVendor := true
-	if root == vendorPath {
-		skipVendor = false
-	}
-	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() {
-			return nil
-		}
-		if skipVendor && strings.HasPrefix(path, vendorPath) {
-			return filepath.SkipDir
-		}
-		for _, r := range v.skippedPaths {
-			if r.MatchString(path) {
-				return filepath.SkipDir
-			}
-		}
-		ipath, err := filepath.Rel(root, path)
-		if err != nil {
-			return err
-		}
-		pkg, err := v.importPkg(".", filepath.Join(v.root, path))
-		if err != nil {
-			if _, ok := err.(*build.NoGoError); err != nil && ok {
-				return nil
-			}
-			return err
-		}
-
-		return f(path, ipath, pkg)
-	})
-}
-
-func (v *Vendorer) walkRepo() error {
-	for _, root := range v.cfg.SrcDirs {
-		if err := v.walk(root, v.updatePkg); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (v *Vendorer) updateSinglePkg(path string) error {
-	pkg, err := v.importPkg(".", "./"+path)
-	if err != nil {
-		if _, ok := err.(*build.NoGoError); err != nil && ok {
-			return nil
-		}
-		return err
-	}
-	return v.updatePkg(path, "", pkg)
-}
-
-type ruleType int
-
-// The RuleType* constants enumerate the bazel rules supported by this tool.
-const (
-	RuleTypeGoBinary ruleType = iota
-	RuleTypeGoLibrary
-	RuleTypeGoTest
-	RuleTypeGoXTest
-	RuleTypeCGoGenrule
-	RuleTypeFileGroup
-)
-
-// RuleKind converts a value of the RuleType* enum into the BUILD string.
-func (rt ruleType) RuleKind() string {
-	switch rt {
-	case RuleTypeGoBinary:
-		return "go_binary"
-	case RuleTypeGoLibrary:
-		return "go_library"
-	case RuleTypeGoTest:
-		return "go_test"
-	case RuleTypeGoXTest:
-		return "go_test"
-	case RuleTypeCGoGenrule:
-		return "cgo_genrule"
-	case RuleTypeFileGroup:
-		return "filegroup"
-	}
-	panic("unreachable")
-}
-
-// NamerFunc is a function that returns the appropriate name for the rule for the provided RuleType.
-type NamerFunc func(ruleType) string
-
-func (v *Vendorer) updatePkg(path, _ string, pkg *build.Package) error {
-
-	srcNameMap := func(srcs ...[]string) *bzl.ListExpr {
-		return asExpr(merge(srcs...)).(*bzl.ListExpr)
-	}
-
-	srcs := srcNameMap(pkg.GoFiles, pkg.SFiles)
-	cgoSrcs := srcNameMap(pkg.CgoFiles, pkg.CFiles, pkg.CXXFiles, pkg.HFiles)
-	testSrcs := srcNameMap(pkg.TestGoFiles)
-	xtestSrcs := srcNameMap(pkg.XTestGoFiles)
-
-	v.addRules(path, v.emit(srcs, cgoSrcs, testSrcs, xtestSrcs, pkg, func(rt ruleType) string {
-		switch rt {
-		case RuleTypeGoBinary:
-			return filepath.Base(pkg.Dir)
-		case RuleTypeGoLibrary:
-			return "go_default_library"
-		case RuleTypeGoTest:
-			return "go_default_test"
-		case RuleTypeGoXTest:
-			return "go_default_xtest"
-		case RuleTypeCGoGenrule:
-			return "cgo_codegen"
-		}
-		panic("unreachable")
-	}))
-
-	return nil
-}
-
-func (v *Vendorer) emit(srcs, cgoSrcs, testSrcs, xtestSrcs *bzl.ListExpr, pkg *build.Package, namer NamerFunc) []*bzl.Rule {
-	var goLibAttrs = make(Attrs)
-	var rules []*bzl.Rule
-
-	deps := v.extractDeps(pkg.Imports)
-
-	if len(srcs.List) >= 0 {
-		goLibAttrs.Set("srcs", srcs)
-	} else if len(cgoSrcs.List) == 0 {
-		return nil
-	}
-
-	if len(deps.List) > 0 {
-		goLibAttrs.SetList("deps", deps)
-	}
-
-	if pkg.IsCommand() {
-		rules = append(rules, newRule(RuleTypeGoBinary, namer, map[string]bzl.Expr{
-			"library": asExpr(":" + namer(RuleTypeGoLibrary)),
-		}))
-	}
-
-	addGoDefaultLibrary := len(cgoSrcs.List) > 0 || len(srcs.List) > 0
-	if len(cgoSrcs.List) != 0 {
-		cgoRuleAttrs := make(Attrs)
-
-		cgoRuleAttrs.SetList("srcs", cgoSrcs)
-		cgoRuleAttrs.SetList("clinkopts", asExpr([]string{"-lz", "-lm", "-lpthread", "-ldl"}).(*bzl.ListExpr))
-
-		rules = append(rules, newRule(RuleTypeCGoGenrule, namer, cgoRuleAttrs))
-
-		goLibAttrs.Set("library", asExpr(":"+namer(RuleTypeCGoGenrule)))
-	}
-
-	if len(testSrcs.List) != 0 {
-		testRuleAttrs := make(Attrs)
-
-		testRuleAttrs.SetList("srcs", testSrcs)
-		testRuleAttrs.SetList("deps", v.extractDeps(pkg.TestImports))
-
-		if addGoDefaultLibrary {
-			testRuleAttrs.Set("library", asExpr(":"+namer(RuleTypeGoLibrary)))
-		}
-		rules = append(rules, newRule(RuleTypeGoTest, namer, testRuleAttrs))
-	}
-
-	if addGoDefaultLibrary {
-		rules = append(rules, newRule(RuleTypeGoLibrary, namer, goLibAttrs))
-	}
-
-	if len(xtestSrcs.List) != 0 {
-		xtestRuleAttrs := make(Attrs)
-
-		xtestRuleAttrs.SetList("srcs", xtestSrcs)
-		xtestRuleAttrs.SetList("deps", v.extractDeps(pkg.XTestImports))
-
-		rules = append(rules, newRule(RuleTypeGoXTest, namer, xtestRuleAttrs))
-	}
-
-	return rules
-}
-
 func (v *Vendorer) addRules(pkgPath string, rules []*bzl.Rule) {
 	cleanPath := filepath.Clean(pkgPath)
 	v.newRules[cleanPath] = append(v.newRules[cleanPath], rules...)
-}
-
-func (v *Vendorer) walkVendor() error {
-	var rules []*bzl.Rule
-	updateFunc := func(path, ipath string, pkg *build.Package) error {
-		srcNameMap := func(srcs ...[]string) *bzl.ListExpr {
-			return asExpr(
-				apply(
-					merge(srcs...),
-					mapper(func(s string) string {
-						return strings.TrimPrefix(filepath.Join(path, s), "vendor/")
-					}),
-				),
-			).(*bzl.ListExpr)
-		}
-
-		srcs := srcNameMap(pkg.GoFiles, pkg.SFiles)
-		cgoSrcs := srcNameMap(pkg.CgoFiles, pkg.CFiles, pkg.CXXFiles, pkg.HFiles)
-		testSrcs := srcNameMap(pkg.TestGoFiles)
-		xtestSrcs := srcNameMap(pkg.XTestGoFiles)
-
-		tagBase := v.resolve(ipath).tag
-
-		rules = append(rules, v.emit(srcs, cgoSrcs, testSrcs, xtestSrcs, pkg, func(rt ruleType) string {
-			switch rt {
-			case RuleTypeGoBinary:
-				return tagBase + "_bin"
-			case RuleTypeGoLibrary:
-				return tagBase
-			case RuleTypeGoTest:
-				return tagBase + "_test"
-			case RuleTypeGoXTest:
-				return tagBase + "_xtest"
-			case RuleTypeCGoGenrule:
-				return tagBase + "_cgo"
-			}
-			panic("unreachable")
-		})...)
-
-		return nil
-	}
-	if v.cfg.VendorMultipleBuildFiles {
-		updateFunc = v.updatePkg
-	}
-	if err := v.walk(vendorPath, updateFunc); err != nil {
-		return err
-	}
-	v.addRules(vendorPath, rules)
-
-	return nil
-}
-
-func (v *Vendorer) extractDeps(deps []string) *bzl.ListExpr {
-	return asExpr(
-		apply(
-			merge(deps),
-			filterer(func(s string) bool {
-				pkg, err := v.importPkg(s, v.root)
-				if err != nil {
-					if strings.Contains(err.Error(), `cannot find package "C"`) ||
-						// added in go1.7
-						strings.Contains(err.Error(), `cannot find package "context"`) ||
-						strings.Contains(err.Error(), `cannot find package "net/http/httptrace"`) {
-						return false
-					}
-					fmt.Fprintf(os.Stderr, "extract err: %v\n", err)
-					return false
-				}
-				if pkg.Goroot {
-					return false
-				}
-				return true
-			}),
-			mapper(func(s string) string {
-				return v.resolve(s).String()
-			}),
-		),
-	).(*bzl.ListExpr)
 }
 
 func (v *Vendorer) reconcileAllRules() (int, error) {
@@ -495,7 +157,7 @@ func (v *Vendorer) reconcileAllRules() (int, error) {
 	sort.Strings(paths)
 	written := 0
 	for _, path := range paths {
-		w, err := ReconcileRules(path, v.newRules[path], v.managedAttrs, v.dryRun, v.cfg.ManageGoRules)
+		w, err := ReconcileRules(path, v.newRules[path], v.managedAttrs, v.dryRun)
 		if w {
 			written++
 		}
@@ -504,31 +166,6 @@ func (v *Vendorer) reconcileAllRules() (int, error) {
 		}
 	}
 	return written, nil
-}
-
-// Attrs collects the attributes for a rule.
-type Attrs map[string]bzl.Expr
-
-// Set sets the named attribute to the provided bazel expression.
-func (a Attrs) Set(name string, expr bzl.Expr) {
-	a[name] = expr
-}
-
-// SetList sets the named attribute to the provided bazel expression list.
-func (a Attrs) SetList(name string, expr *bzl.ListExpr) {
-	if len(expr.List) == 0 {
-		return
-	}
-	a[name] = expr
-}
-
-// Label defines a bazel label.
-type Label struct {
-	pkg, tag string
-}
-
-func (l Label) String() string {
-	return fmt.Sprintf("//%v:%v", l.pkg, l.tag)
 }
 
 // addCommentBefore adds a whole-line comment before the provided Expr.
@@ -606,60 +243,13 @@ func asExpr(e interface{}) bzl.Expr {
 	}
 }
 
-type sed func(s []string) []string
-
-func mapString(in []string, f func(string) string) []string {
-	var out []string
-	for _, s := range in {
-		out = append(out, f(s))
-	}
-	return out
-}
-
-func mapper(f func(string) string) sed {
-	return func(in []string) []string {
-		return mapString(in, f)
-	}
-}
-
-func filterString(in []string, f func(string) bool) []string {
-	var out []string
-	for _, s := range in {
-		if f(s) {
-			out = append(out, s)
-		}
-	}
-	return out
-}
-
-func filterer(f func(string) bool) sed {
-	return func(in []string) []string {
-		return filterString(in, f)
-	}
-}
-
-func apply(stream []string, seds ...sed) []string {
-	for _, sed := range seds {
-		stream = sed(stream)
-	}
-	return stream
-}
-
-func merge(streams ...[]string) []string {
-	var out []string
-	for _, stream := range streams {
-		out = append(out, stream...)
-	}
-	return out
-}
-
-func newRule(rt ruleType, namer NamerFunc, attrs map[string]bzl.Expr) *bzl.Rule {
+func newRule(rt, name string, attrs map[string]bzl.Expr) *bzl.Rule {
 	rule := &bzl.Rule{
 		Call: &bzl.CallExpr{
-			X: &bzl.LiteralExpr{Token: rt.RuleKind()},
+			X: &bzl.LiteralExpr{Token: rt},
 		},
 	}
-	rule.SetAttr("name", asExpr(namer(rt)))
+	rule.SetAttr("name", asExpr(name))
 	for k, v := range attrs {
 		rule.SetAttr(k, v)
 	}
@@ -678,20 +268,16 @@ func findBuildFile(pkgPath string) (bool, string) {
 			return true, path
 		}
 	}
-	return false, filepath.Join(pkgPath, "BUILD")
+	return false, filepath.Join(pkgPath, "BUILD.bazel")
 }
 
 // ReconcileRules reconciles, simplifies, and writes the rules for the specified package, adding
 // additional dependency rules as needed.
-func ReconcileRules(pkgPath string, rules []*bzl.Rule, managedAttrs []string, dryRun bool, manageGoRules bool) (bool, error) {
+func ReconcileRules(pkgPath string, rules []*bzl.Rule, managedAttrs []string, dryRun bool) (bool, error) {
 	_, path := findBuildFile(pkgPath)
 	info, err := os.Stat(path)
 	if err != nil && os.IsNotExist(err) {
 		f := &bzl.File{}
-		writeHeaders(f)
-		if manageGoRules {
-			reconcileLoad(f, rules)
-		}
 		writeRules(f, rules)
 		return writeFile(path, f, nil, false, dryRun)
 	} else if err != nil {
@@ -718,7 +304,7 @@ func ReconcileRules(pkgPath string, rules []*bzl.Rule, managedAttrs []string, dr
 			f.Stmt = append(f.Stmt, r.Call)
 			continue
 		}
-		if !RuleIsManaged(o, manageGoRules) {
+		if !RuleIsManaged(o) {
 			continue
 		}
 		reconcileAttr := func(o, n *bzl.Rule, name string) {
@@ -735,69 +321,24 @@ func ReconcileRules(pkgPath string, rules []*bzl.Rule, managedAttrs []string, dr
 	}
 
 	for _, r := range oldRules {
-		if !RuleIsManaged(r, manageGoRules) {
+		if !RuleIsManaged(r) {
 			continue
 		}
 		f.DelRules(r.Kind(), r.Name())
-	}
-	if manageGoRules {
-		reconcileLoad(f, f.Rules(""))
 	}
 
 	return writeFile(path, f, nil, true, dryRun)
 }
 
-func reconcileLoad(f *bzl.File, rules []*bzl.Rule) {
-	usedRuleKindsMap := map[string]bool{}
-	for _, r := range rules {
-		// Select only the Go rules we need to import, excluding builtins like filegroup.
-		// TODO: make less fragile
-		switch r.Kind() {
-		case "go_prefix", "go_library", "go_binary", "go_test", "go_proto_library", "cgo_genrule", "cgo_library":
-			usedRuleKindsMap[r.Kind()] = true
-		}
-	}
-
-	usedRuleKindsList := []string{}
-	for k := range usedRuleKindsMap {
-		usedRuleKindsList = append(usedRuleKindsList, k)
-	}
-	sort.Strings(usedRuleKindsList)
-
-	for _, r := range f.Rules("load") {
-		const goRulesLabel = "@io_bazel_rules_go//go:def.bzl"
-		args := bzl.Strings(&bzl.ListExpr{List: r.Call.List})
-		if len(args) == 0 {
-			continue
-		}
-		if args[0] != goRulesLabel {
-			continue
-		}
-		if len(usedRuleKindsList) == 0 {
-			f.DelRules(r.Kind(), r.Name())
-			continue
-		}
-		r.Call.List = asExpr(append(
-			[]string{goRulesLabel}, usedRuleKindsList...,
-		)).(*bzl.ListExpr).List
-		break
-	}
-}
-
 // RuleIsManaged returns whether the provided rule is managed by this tool,
 // based on the tags set on the rule.
-func RuleIsManaged(r *bzl.Rule, manageGoRules bool) bool {
-	var automanaged bool
-	if !manageGoRules && (strings.HasPrefix(r.Kind(), "go_") || strings.HasPrefix(r.Kind(), "cgo_")) {
-		return false
-	}
+func RuleIsManaged(r *bzl.Rule) bool {
 	for _, tag := range r.AttrStrings("tags") {
 		if tag == automanagedTag {
-			automanaged = true
-			break
+			return true
 		}
 	}
-	return automanaged
+	return false
 }
 
 // writeFile writes out f to path, prepending boilerplate to the output.
@@ -832,22 +373,6 @@ func writeFile(path string, f *bzl.File, boilerplate []byte, exists, dryRun bool
 		fmt.Fprintf(os.Stderr, "wrote %q\n", path)
 	}
 	return werr == nil, werr
-}
-
-func context() *build.Context {
-	return &build.Context{
-		GOARCH:      build.Default.GOARCH,
-		GOOS:        build.Default.GOOS,
-		GOROOT:      build.Default.GOROOT,
-		GOPATH:      build.Default.GOPATH,
-		Compiler:    runtime.Compiler,
-		CgoEnabled:  true,
-		UseAllFiles: true,
-	}
-}
-
-func walk(root string, walkFn filepath.WalkFunc) error {
-	return nil
 }
 
 func compileSkippedPaths(skippedPaths []string) ([]*regexp.Regexp, error) {

--- a/kazel/sourcerer.go
+++ b/kazel/sourcerer.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	bzl "github.com/bazelbuild/buildtools/build"
+	"github.com/bazelbuild/buildtools/build"
 )
 
 const (
@@ -85,21 +85,21 @@ func (v *Vendorer) walkSource(pkgPath string) ([]string, error) {
 		return nil, nil
 	}
 
-	pkgSrcsExpr := &bzl.LiteralExpr{Token: `glob(["**"])`}
+	pkgSrcsExpr := &build.LiteralExpr{Token: `glob(["**"])`}
 	if pkgPath == "." {
-		pkgSrcsExpr = &bzl.LiteralExpr{Token: `glob(["**"], exclude=["bazel-*/**", ".git/**"])`}
+		pkgSrcsExpr = &build.LiteralExpr{Token: `glob(["**"], exclude=["bazel-*/**", ".git/**"])`}
 	}
 
-	v.addRules(pkgPath, []*bzl.Rule{
+	v.addRules(pkgPath, []*build.Rule{
 		newRule("filegroup",
 			pkgSrcsTarget,
-			map[string]bzl.Expr{
+			map[string]build.Expr{
 				"srcs":       pkgSrcsExpr,
 				"visibility": asExpr([]string{"//visibility:private"}),
 			}),
 		newRule("filegroup",
 			allSrcsTarget,
-			map[string]bzl.Expr{
+			map[string]build.Expr{
 				"srcs": asExpr(append(children, fmt.Sprintf(":%s", pkgSrcsTarget))),
 				// TODO: should this be more restricted?
 				"visibility": asExpr([]string{"//visibility:public"}),

--- a/kazel/sourcerer.go
+++ b/kazel/sourcerer.go
@@ -91,14 +91,14 @@ func (v *Vendorer) walkSource(pkgPath string) ([]string, error) {
 	}
 
 	v.addRules(pkgPath, []*bzl.Rule{
-		newRule(RuleTypeFileGroup,
-			func(_ ruleType) string { return pkgSrcsTarget },
+		newRule("filegroup",
+			pkgSrcsTarget,
 			map[string]bzl.Expr{
 				"srcs":       pkgSrcsExpr,
 				"visibility": asExpr([]string{"//visibility:private"}),
 			}),
-		newRule(RuleTypeFileGroup,
-			func(_ ruleType) string { return allSrcsTarget },
+		newRule("filegroup",
+			allSrcsTarget,
 			map[string]bzl.Expr{
 				"srcs": asExpr(append(children, fmt.Sprintf(":%s", pkgSrcsTarget))),
 				// TODO: should this be more restricted?

--- a/verify/boilerplate/test/BUILD.bazel
+++ b/verify/boilerplate/test/BUILD.bazel
@@ -14,5 +14,4 @@ go_library(
         "pass.go",
     ],
     importpath = "k8s.io/repo-infra/verify/boilerplate/test",
-    tags = ["automanaged"],
 )


### PR DESCRIPTION
This is a follow-on to https://github.com/kubernetes/repo-infra/pull/80, inspired by https://github.com/kubernetes/repo-infra/pull/80#discussion_r229140501. You probably only want to look at the last two commits for now.

We haven't used kazel to manage go rules for quite a while, and I'm pretty sure it wouldn't even generate valid rules anymore. Let's remove all this unnecessary code.

/assign @fejta @BenTheElder 