### PR TITLE
Fix build for bazel 0.20.0+

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,9 +1,11 @@
 workspace(name = "io_kubernetes_build")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "5f3b0304cdf0c505ec9e5b3c4fc4a87b5ca21b13d8ecc780c97df3d1809b9ce6",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.15.1/rules_go-0.15.1.tar.gz",
+    sha256 = "b7a62250a3a73277ade0ce306d22f122365b513f5402222403e507f2f997d421",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.16.3/rules_go-0.16.3.tar.gz",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_register_toolchains", "go_rules_dependencies")


### PR DESCRIPTION
We need to use the starlark implementation of `http_archive`, and we need an updated `rules_go` too.

/assign @BenTheElder @fejta 