### PR TITLE
Use a correct Bazel workspace name for repo-infra

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "io_kubernetes_build")
+workspace(name = "io_k8s_repo_infra")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 


### PR DESCRIPTION
The Bazel workspace name should really match the repo name, so changing `io_kubernetes_build` to `io_k8s_repo_infra`.

Whenever projects update their `repo-infra` dependency, they'll need to switch the name as well.

x-ref https://github.com/kubernetes/test-infra/pull/10757

/assign @fejta @BenTheElder 