### PR TITLE
Two tar fixes

### DIFF
--- a/defs/pkg.bzl
+++ b/defs/pkg.bzl
@@ -19,7 +19,11 @@ load(
 
 # pkg_tar wraps the official pkg_tar rule with our faster
 # Go-based build_tar binary.
-def pkg_tar(**kwargs):
-    if "build_tar" not in kwargs:
-        kwargs["build_tar"] = "@io_k8s_repo_infra//tools/build_tar"
-    _real_pkg_tar(**kwargs)
+# Additionally, the upstream pkg_tar rule defaults mode to "0555",
+# which prevents build_tar from automatically choosing an
+# appropriate mode, so we instead default it to "".
+def pkg_tar(
+        build_tar = "@io_k8s_repo_infra//tools/build_tar",
+        mode = "",
+        **kwargs):
+    _real_pkg_tar(build_tar = build_tar, mode = mode, **kwargs)

--- a/tools/build_tar/buildtar.go
+++ b/tools/build_tar/buildtar.go
@@ -374,6 +374,9 @@ func (f *tarFile) makeDirs(header tar.Header) error {
 			continue
 		}
 		dh := header
+		// Add the x bit to directories if the read bit is set,
+		// and make sure all directories are at least user RWX.
+		dh.Mode = header.Mode | 0700 | ((0444 & header.Mode) >> 2)
 		dh.Typeflag = tar.TypeDir
 		dh.Name = dir + "/"
 		if err := f.tw.WriteHeader(&dh); err != nil {


### PR DESCRIPTION
I have no idea how this ever worked:
- Bazel's `pkg_tar` defaults `mode = "0555"`, which means that directories inside the tarball are not writable, which causes problems during extraction. If we override that default to `""`, we can let `build_tar` choose an appropriate default. (The upstream `build_tar` also has this functionality, even.)
- When creating parent directories, our `build_tar` used the mode of whatever was being added, which meant the directories might be missing the `x` or `w` bit. I blatantly stole the upstream approach to set the `x` bit when the `r` bit is set, and have also ensured that all parent directories have user mode RWX.

/assign @mikedanese @fejta @BenTheElder 