### PR TITLE
bazel 0.27: rename single_file to allow_single_file

### DIFF
--- a/defs/run_in_workspace.bzl
+++ b/defs/run_in_workspace.bzl
@@ -47,13 +47,11 @@ _workspace_binary_script = rule(
     attrs = {
         "cmd": attr.label(
             mandatory = True,
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
         ),
         "root_file": attr.label(
             mandatory = True,
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
         ),
     },
     executable = True,


### PR DESCRIPTION
Fix to be compatible with bazel 0.27