### PR TITLE
Update workspace_binary to work with bazel 0.27.0+

### DIFF
--- a/defs/run_in_workspace.bzl
+++ b/defs/run_in_workspace.bzl
@@ -47,13 +47,11 @@ _workspace_binary_script = rule(
     attrs = {
         "cmd": attr.label(
             mandatory = True,
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
         ),
         "root_file": attr.label(
             mandatory = True,
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
         ),
     },
     executable = True,


### PR DESCRIPTION
`single_file` is now incompatible in bazel 0.27.0

```

ERROR: /root/.cache/bazel/_bazel_root/f81142f9bbb790a9b9dba33eee093d1f/external/io_kubernetes_build/defs/run_in_workspace.bzl:48:16: Traceback (most recent call last):
--
  | File "/root/.cache/bazel/_bazel_root/f81142f9bbb790a9b9dba33eee093d1f/external/io_kubernetes_build/defs/run_in_workspace.bzl", line 46
  | rule(attrs = {"cmd": attr.label(manda...)}, <2 more arguments>)
  | File "/root/.cache/bazel/_bazel_root/f81142f9bbb790a9b9dba33eee093d1f/external/io_kubernetes_build/defs/run_in_workspace.bzl", line 48, in rule
  | attr.label(mandatory = True, allow_files = Tr..., ...)
  | 'single_file' is no longer supported. use allow_single_file instead. You can use --incompatible_disable_deprecated_attr_params=false to temporarily disable this check.

```