### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/defs/gcs_uploader.py
+++ b/defs/gcs_uploader.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
 import argparse
 import atexit
 import os
@@ -77,7 +78,7 @@ def main(argv):
 
         uploaded_paths.append(gcs_path)
 
-    print "Uploaded to %s" % " ".join(uploaded_paths)
+    print("Uploaded to %s" % " ".join(uploaded_paths))
     sys.exit(ret)
 
 


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

Why does k8s-ci-robot fail my CLA https://identity.linuxfoundation.org/users/cclauss ??