### PR TITLE
Fix mode on symlinks

### DIFF
--- a/tools/build_tar/buildtar.go
+++ b/tools/build_tar/buildtar.go
@@ -288,6 +288,7 @@ func (f *tarFile) addLink(symlink, target string) error {
 		Name:     symlink,
 		Typeflag: tar.TypeSymlink,
 		Linkname: target,
+		Mode:     int64(0777), // symlinks should always have 0777 mode
 		ModTime:  f.meta.modTime,
 	}
 	if err := f.makeDirs(header); err != nil {


### PR DESCRIPTION
This fixes a bug in our build_tar implementation, where we were not forcing 0777 on symlinks. This is a specific issue on Darwin, because you can actually set the mode on symlinks (Linux just assumes 0777 for the symlink itself).