### PR TITLE
Generate all-srcs targets in repo-infra

### DIFF
--- a/.kazelcfg.json
+++ b/.kazelcfg.json
@@ -1,3 +1,4 @@
 {
-	"GoPrefix": "k8s.io/repo-infra"
+	"GoPrefix": "k8s.io/repo-infra",
+	"AddSourcesRules": true
 }

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -38,3 +38,29 @@ workspace_binary(
 load("@bazel_gazelle//:def.bzl", "gazelle")
 
 gazelle(name = "gazelle")
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(
+        ["**"],
+        exclude = [
+            "bazel-*/**",
+            ".git/**",
+        ],
+    ),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//cmd/kazel:all-srcs",
+        "//defs:all-srcs",
+        "//tools/build_tar:all-srcs",
+        "//verify:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/kazel/BUILD.bazel
+++ b/cmd/kazel/BUILD.bazel
@@ -39,3 +39,17 @@ go_test(
     embed = [":go_default_library"],
     deps = ["@com_github_bazelbuild_buildtools//build:go_default_library"],
 )
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/defs/BUILD.bazel
+++ b/defs/BUILD.bazel
@@ -41,3 +41,21 @@ release_filegroup(
         "sha512",
     ]
 ]
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//defs/testgen:all-srcs",
+        "//defs/testpkg:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/defs/testgen/BUILD.bazel
+++ b/defs/testgen/BUILD.bazel
@@ -12,3 +12,17 @@ go_binary(
     embed = [":go_default_library"],
     visibility = ["//defs:__subpackages__"],
 )
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/defs/testpkg/BUILD.bazel
+++ b/defs/testpkg/BUILD.bazel
@@ -22,3 +22,17 @@ go_genrule(
     cmd = "$(location //defs/testgen) -in=$< -out=$@ -pkg k8s.io/repo-infra/defs/testpkg",
     tools = ["//defs/testgen"],
 )
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/build_tar/BUILD.bazel
+++ b/tools/build_tar/BUILD.bazel
@@ -16,3 +16,17 @@ go_binary(
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/verify/BUILD.bazel
+++ b/verify/BUILD.bazel
@@ -1,0 +1,16 @@
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//verify/boilerplate:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/verify/boilerplate/BUILD.bazel
+++ b/verify/boilerplate/BUILD.bazel
@@ -1,3 +1,20 @@
 package(default_visibility = ["//visibility:public"])
 
 exports_files(glob(["*.txt"]))
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//verify/boilerplate/test:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/verify/boilerplate/test/BUILD.bazel
+++ b/verify/boilerplate/test/BUILD.bazel
@@ -15,3 +15,17 @@ go_library(
     ],
     importpath = "k8s.io/repo-infra/verify/boilerplate/test",
 )
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/verify/update-bazel.sh
+++ b/verify/update-bazel.sh
@@ -28,4 +28,4 @@ bazel run //:gazelle -- fix -mode=fix
 bazel run //:gazelle -- update-repos \
   --from_file=go.mod --to_macro=repos.bzl%go_repositories \
   --build_file_generation=on --build_file_proto_mode=disable
-bazel run //:kazel
+bazel run //:kazel -- --cfg-path=./.kazelcfg.json

--- a/verify/verify-bazel.sh
+++ b/verify/verify-bazel.sh
@@ -19,7 +19,7 @@ set -o pipefail
 
 cd $(git rev-parse --show-toplevel)
 gazelle_diff=$(bazel run //:gazelle -- fix -mode=diff)
-kazel_diff=$(bazel run //:kazel -- -dry-run -print-diff)
+kazel_diff=$(bazel run //:kazel -- -dry-run -print-diff --cfg-path=./.kazelcfg.json)
 
 if [[ -n "${gazelle_diff}" || -n "${kazel_diff}" ]]; then
   echo "${gazelle_diff}"


### PR DESCRIPTION
This PR replaces #138 

It also fixes #149 

Generate all-srcs targets in this repository, and fix issues with formatting the `srcs` attribute in `package-srcs` rules (and any other formatting issue that arises through similar usage of `LiteralExpr` in future modifiers)

/cc @fejta 