### PR TITLE
Fix 'external' exclude in verify-boilerplate

### DIFF
--- a/hack/verify_boilerplate.py
+++ b/hack/verify_boilerplate.py
@@ -40,7 +40,7 @@ def get_args():
     parser.add_argument(
         '--skip',
         default=[
-            'external',
+            'external/bazel_tools',
             '.git',
             'node_modules',
             '_output',


### PR DESCRIPTION
The verify boilerplate target does exclude paths containing "external",
which applies to any cached bazel path. This breaks the functionality of
the tool itself, which is now fixed.

For example, a checked path within this repository looks like this on my machine:
```
/home/sascha/.cache/bazel/_bazel_sascha/5df1a239efadbb300829867a187a68dd/sandbox/linux-sandbox/59/execroot/io_k8s_repo_infra/bazel-out/k8-fastbuild/bin/external/io_k8s_repo_infra/hack/verify-boilerplate.runfiles/io_k8s_repo_infra/hack/tools.go
```