### PR TITLE
repo-infra: fix //:push-build

### DIFF
--- a/defs/BUILD.bazel
+++ b/defs/BUILD.bazel
@@ -1,7 +1,8 @@
 load(":pkg.bzl", "pkg_tar")
 load(":build.bzl", "release_filegroup")
+load("@subpar//:subpar.bzl", "par_binary")
 
-py_binary(
+par_binary(
     name = "gcs_uploader",
     srcs = [
         "gcs_uploader.py",

--- a/defs/build.bzl
+++ b/defs/build.bzl
@@ -58,7 +58,7 @@ gcs_upload = rule(
             allow_files = True,
         ),
         "uploader": attr.label(
-            default = Label("//defs:gcs_uploader"),
+            default = Label("//defs:gcs_uploader.par"),
             allow_files = True,
         ),
         # TODO: combine with 'data' when label_keyed_string_dict is supported in Bazel

--- a/load.bzl
+++ b/load.bzl
@@ -15,6 +15,13 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def repositories():
+    if not native.existing_rule("subpar"):
+        http_archive(
+            name = "subpar",
+            urls = ["https://github.com/google/subpar/archive/2.0.0.tar.gz"],
+            sha256 = "b80297a1b8d38027a86836dbadc22f55dc3ecad56728175381aa6330705ac10f",
+            strip_prefix = "subpar-2.0.0",
+        )
     if not native.existing_rule("bazel_skylib"):
         http_archive(
             name = "bazel_skylib",


### PR DESCRIPTION
Use a par. py_binary data deps aren't transitively added to runfiles of
rules that depend on them. Easiest way to fix is to use a par. This was
tested in k/k.