### PR TITLE
export goroot in go_genrule

### DIFF
--- a/defs/go.bzl
+++ b/defs/go.bzl
@@ -86,6 +86,7 @@ def _go_genrule_impl(ctx):
     env.update({
         "PATH": ctx.configuration.host_path_separator.join(["/bin", "/usr/bin"]),
         "GOPATH": paths.join(ctx.bin_dir.path, paths.dirname(ctx.build_file_path), "gopath"),
+        "GOROOT": paths.dirname(go.sdk.root_file.path),
     })
 
     ctx.actions.run_shell(


### PR DESCRIPTION
This is needed to resolve stdlib types. E.g.:

https://github.com/kubernetes/kubernetes/blob/2ab6357df0a513593b425f8abde6578687d44034/staging/src/k8s.io/kube-scheduler/config/v1/types.go#L210-L212

Unclear why that's not metav1.Duration since time.Duration doesn't have a friendly json encoding but that's a seperate issue... https://github.com/kubernetes/kubernetes/issues/89396

/assign @BenTheElder @fejta 