### PR TITLE
Minor update to allowed dates in boilerplate

### DIFF
--- a/hack/verify_boilerplate.py
+++ b/hack/verify_boilerplate.py
@@ -225,7 +225,7 @@ def get_regexs():
     regexs = {}
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile('YEAR')
-    # dates can be 2014, 2015, 2016 or 2017, company holder names can be anything
+    # dates can be any year between 2014 and the current year, company holder names can be anything
     regexs["date"] = re.compile(get_dates())
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(


### PR DESCRIPTION
The allowed dates in the boilerplate header adjusts to include 2014
through the current year, but the comment suggests that these values are
hard-coded. This updates the comment to describe available dates more
accurately.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>