### PR TITLE
Remove nicoaragon from owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,7 +3,6 @@ approvers:
 - clarketm
 - fejta
 - mikedanese
-- nicoaragon
 
 emeritus_approvers:
 - ixdy


### PR DESCRIPTION
The user no longer exists (more likely renamed): https://github.com/nicoaragon
It is blocking others when using it as a submodule by applying the invalid owners label.
ref: https://github.com/kubernetes-sigs/kubefed/pull/1244
ref: https://kubernetes.slack.com/archives/C1TU9EB9S/p1593719089153000

/cc @cblecker 