### PR TITLE
OWNERS: Add justaugustus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@ approvers:
 - BenTheElder
 - clarketm
 - fejta
+- justaugustus
 - mikedanese
 
 emeritus_approvers:


### PR DESCRIPTION
Discussed with @fejta earlier today.
k/repo-infra is in the critical path for Release Engineering work, both
as a consumer in k/release, and as owners for the Go update process.

Adding myself as an approver here to provide reviews, as well as
minimizing the chokepoint possibilities when we're trying to work
through Golang updates.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @fejta @BenTheElder @mikedanese 