### PR TITLE
OWNERS: Add Verolop to reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,5 +5,12 @@ approvers:
 - justaugustus
 - mikedanese
 
+reviewers:
+- Verolop
+
 emeritus_approvers:
 - ixdy
+
+labels:
+- sig/release
+- area/release-eng


### PR DESCRIPTION
Plus some labels for the PRs!

@Verolop is an experienced bazel user and we could use the additional eyes!

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @fejta @Verolop 
cc: @kubernetes/release-engineering 