### PR TITLE
deps: Update rules_go to v0.22.9

### DIFF
--- a/load.bzl
+++ b/load.bzl
@@ -58,14 +58,15 @@ def repositories():
         )
 
     # Check https://github.com/bazelbuild/rules_go/releases for new releases
-    # 0.22.8 supports Golang 1.14.6 and 1.13.14
+    # v0.22.9 supports Golang 1.14.6 and 1.13.14
+    # If this is updated, please ensure that bazel-toolchains is also updated
     if not native.existing_rule("io_bazel_rules_go"):
         http_archive(
             name = "io_bazel_rules_go",
-            sha256 = "38392eb0617c1a9fdff17c4a284f012da13e4feefbaf87d04b3579b107902e9b",
+            sha256 = "ae6814b6a8e09e7a9f5b20c1add51ada6a2cc664d4659aeca2921c10674e24e3",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.22.8/rules_go-v0.22.8.tar.gz",
-                "https://github.com/bazelbuild/rules_go/releases/download/v0.22.8/rules_go-v0.22.8.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.22.9/rules_go-v0.22.9.tar.gz",
+                "https://github.com/bazelbuild/rules_go/releases/download/v0.22.9/rules_go-v0.22.9.tar.gz",
             ],
         )
 


### PR DESCRIPTION
**Needed for k/k go1.15 update (ref: https://github.com/kubernetes/kubernetes/pull/93264#issuecomment-662791494)**

ref: https://github.com/bazelbuild/rules_go/releases/tag/v0.22.9

- The builder will invoke the Go compiler and linker using response
  files when the length of arguments exceeds operating system limits.
- go_test will now recompile packages imported by external tests that
  transitively import the library under test. To avoid conflicts with
  the Go 1.15 linker (which has a stricter export data check), it's
  necessary to recompile these packages against the internal test
  archive.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

Thanks @jayconrod!

/assign @fejta 
cc: @kubernetes/release-engineering 