### PR TITLE
Support overriding go_sdk versions

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -61,6 +61,7 @@ filegroup(
         ":package-srcs",
         "//cmd/kazel:all-srcs",
         "//defs:all-srcs",
+        "//go:all-srcs",
         "//hack:all-srcs",
         "//tools/build_tar:all-srcs",
         "//verify:all-srcs",

--- a/go/BUILD.bazel
+++ b/go/BUILD.bazel
@@ -1,0 +1,13 @@
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/go/sdk_versions.bzl
+++ b/go/sdk_versions.bzl
@@ -1,0 +1,15 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+OVERRIDE_GO_VERSIONS = {}

--- a/go/sdk_versions.bzl
+++ b/go/sdk_versions.bzl
@@ -12,4 +12,51 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-OVERRIDE_GO_VERSIONS = {}
+OVERRIDE_GO_VERSIONS = {
+    "1.15.0-beta.1": {
+        "darwin_amd64": (
+            "go1.15beta1.darwin-amd64.tar.gz",
+            "4ee49feb46169ef942097513b5e783ff0f3f276b1eacfc51083e6e453117bd7e",
+        ),
+        "freebsd_386": (
+            "go1.15beta1.freebsd-386.tar.gz",
+            "77bc3aae4abaa73b537435b6a497043929cf95d7dd17c289f6e1b55180285c94",
+        ),
+        "freebsd_amd64": (
+            "go1.15beta1.freebsd-amd64.tar.gz",
+            "e13dd8a3e5a04bc1a54b2b70f540fd5e4d77663948c14636e27cf8a8ecfccd7b",
+        ),
+        "linux_386": (
+            "go1.15beta1.linux-386.tar.gz",
+            "83d732a3961006e058f44c9672fde93dbea3d1c3d69e8807d135eeaf21fb80c8",
+        ),
+        "linux_amd64": (
+            "go1.15beta1.linux-amd64.tar.gz",
+            "11814b7475680a09720f3de32c66bca135289c8d528b2e1132b0ce56b3d9d6d7",
+        ),
+        "linux_arm64": (
+            "go1.15beta1.linux-arm64.tar.gz",
+            "2648b7d08fe74d0486ec82b3b539d15f3dd63bb34d79e7e57bebc3e5d06b5a38",
+        ),
+        "linux_arm": (
+            "go1.15beta1.linux-armv6l.tar.gz",
+            "d4da5c06097be8d14aeeb45bf8440a05c82e93e6de26063a147a31ed1d901ebc",
+        ),
+        "linux_ppc64le": (
+            "go1.15beta1.linux-ppc64le.tar.gz",
+            "33f7bed5ee9d4a0343dc90a5aa4ec7a1db755d0749b624618c15178fd8df4420",
+        ),
+        "linux_s390x": (
+            "go1.15beta1.linux-s390x.tar.gz",
+            "493b4449e68d0deba559e3f23f611310467e4c70d30b3605ff06852f14477457",
+        ),
+        "windows_386": (
+            "go1.15beta1.windows-386.zip",
+            "6ef5301bf03a298a023449835a941d53bf0830021d86aa52a5f892def6356b19",
+        ),
+        "windows_amd64": (
+            "go1.15beta1.windows-amd64.zip",
+            "072c7d6a059f76503a2533a20755dddbda58b5053c160cb900271bb039537f88",
+        ),
+    },
+}

--- a/repos.bzl
+++ b/repos.bzl
@@ -18,9 +18,18 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@bazel_skylib//lib:versions.bzl", "versions")
 load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load(
+    "@io_bazel_rules_go//go:deps.bzl",
+    "go_download_sdk",
+    "go_register_toolchains",
+    "go_rules_dependencies",
+)
+load(
+    "@io_k8s_repo_infra//go:sdk_versions.bzl",
+    "OVERRIDE_GO_VERSIONS",
+)
 
-def configure(minimum_bazel_version = None, rbe_name = "rbe_default", go_version = None, nogo = None):
+def configure(minimum_bazel_version = None, rbe_name = "rbe_default", go_version = None, nogo = None, override_go_version = None):
     if minimum_bazel_version:  # Allow an additional downstream constraint
         versions.check(minimum_bazel_version = minimum_bazel_version)
     versions.check(minimum_bazel_version = "2.2.0")  # Minimum rules for this repo
@@ -29,7 +38,12 @@ def configure(minimum_bazel_version = None, rbe_name = "rbe_default", go_version
     protobuf_deps()  # No options
 
     go_rules_dependencies()  # No options
-    go_register_toolchains(go_version = go_version, nogo = nogo)
+
+    if override_go_version:
+        go_download_sdk(name = "go_sdk", sdks = OVERRIDE_GO_VERSIONS[override_go_version])
+        go_register_toolchains(nogo = nogo)
+    else:
+        go_register_toolchains(go_version = go_version, nogo = nogo)
 
     gazelle_dependencies()  # TODO(fejta): go_sdk and go_repository_default_cache
 


### PR DESCRIPTION
(Suggested in https://github.com/kubernetes/repo-infra/pull/197#discussion_r458293039.)

I've roughly borrowed this pattern from rules_go (h/t @jayconrod).
See: https://github.com/bazelbuild/rules_go/blob/9dc42edc13c67d8a70a14e262a7b128ed26a3e54/go/private/sdk.bzl#L23-L28 and https://github.com/bazelbuild/rules_go/blob/9dc42edc13c67d8a70a14e262a7b128ed26a3e54/go/private/sdk_list.bzl#L19

Here we extend the `configure` function in `repos.bzl` to accept an `override_go_version` parameter.

If `override_go_version` is specified, `configure` will make a call to `go_download_sdk` as follows:

```bazel
go_download_sdk(name = "go_sdk", sdks = OVERRIDE_GO_VERSIONS[override_go_version])
```

`OVERRIDE_GO_VERSIONS` is a map that can contain multiple alternate go_sdk versions.
This PR populates the map with go1.15beta1 / `1.15.0-beta.1`, which can be used to test the kubernetes/kubernetes upgrade to go1.15 in https://github.com/kubernetes/kubernetes/pull/93264.

A consumer can leverage this new functionality as follows:

```bazel
load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

http_archive(
    name = "io_k8s_repo_infra",
    strip_prefix = "repo-infra-0.0.8",
    sha256 = "2a86a60706c1f9b2d87f25d2bc1d107d823908ec3fb895735c8aa9a4b239d10e",
    urls = [
        "https://github.com/kubernetes/repo-infra/archive/v0.0.8.tar.gz",
    ],
)

load("@io_k8s_repo_infra//:load.bzl", repo_infra_repositories = "repositories")

repo_infra_repositories()

load("@io_k8s_repo_infra//:repos.bzl", repo_infra_configure = "configure", repo_infra_go_repositories = "go_repositories")

repo_infra_configure(
    override_go_version = "1.15.0-beta.1",
    minimum_bazel_version = "2.2.0",
)

repo_infra_go_repositories()
```

You can see a test of this functionality in https://github.com/kubernetes/kubernetes/pull/93395.
