### PR TITLE
Support go1.15.0

### DIFF
--- a/load.bzl
+++ b/load.bzl
@@ -58,15 +58,15 @@ def repositories():
         )
 
     # Check https://github.com/bazelbuild/rules_go/releases for new releases
-    # v0.22.10 supports Golang 1.14.7 and 1.13.15
+    # v0.22.11 supports Golang 1.15.0
     # If this is updated, please ensure that bazel-toolchains is also updated
     if not native.existing_rule("io_bazel_rules_go"):
         http_archive(
             name = "io_bazel_rules_go",
-            sha256 = "ebb9bcbb2526a5072957ca729d269b43406f672f32e3b3aa4d7f1a4ae7f433fe",
+            sha256 = "e02b302e8b6cb4a771feba99d36d04b13947ef22f51bea38632c0ab885cabe12",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.22.10/rules_go-v0.22.10.tar.gz",
-                "https://github.com/bazelbuild/rules_go/releases/download/v0.22.10/rules_go-v0.22.10.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.22.11/rules_go-v0.22.11.tar.gz",
+                "https://github.com/bazelbuild/rules_go/releases/download/v0.22.11/rules_go-v0.22.11.tar.gz",
             ],
         )
 

--- a/load.bzl
+++ b/load.bzl
@@ -38,11 +38,11 @@ def repositories():
     if not native.existing_rule("bazel_toolchains"):
         http_archive(
             name = "bazel_toolchains",
-            sha256 = "882fecfc88d3dc528f5c5681d95d730e213e39099abff2e637688a91a9619395",
-            strip_prefix = "bazel-toolchains-3.4.0",
+            sha256 = "7ebb200ed3ca3d1f7505659c7dfed01c4b5cb04c3a6f34140726fe22f5d35e86",
+            strip_prefix = "bazel-toolchains-3.4.1",
             urls = [
-                "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.4.0/bazel-toolchains-3.4.0.tar.gz",
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/3.4.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.4.1/bazel-toolchains-3.4.1.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/3.4.1.tar.gz",
             ],
         )
 


### PR DESCRIPTION
- Update rules_go to 0.22.11 to support go1.15.0
- Update bazel-toolchains to 3.4.1

/assign @fejta @Verolop 
cc: @kubernetes/release-engineering

Tracking issue: https://github.com/kubernetes/release/issues/1421