### PR TITLE
Support go1.15.1

### DIFF
--- a/load.bzl
+++ b/load.bzl
@@ -28,10 +28,10 @@ def repositories():
         http_archive(
             name = "bazel_skylib",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
-                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
             ],
-            sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
+            sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
         )
 
     # https://github.com/bazelbuild/bazel-toolchains/releases

--- a/load.bzl
+++ b/load.bzl
@@ -38,11 +38,11 @@ def repositories():
     if not native.existing_rule("bazel_toolchains"):
         http_archive(
             name = "bazel_toolchains",
-            sha256 = "7ebb200ed3ca3d1f7505659c7dfed01c4b5cb04c3a6f34140726fe22f5d35e86",
-            strip_prefix = "bazel-toolchains-3.4.1",
+            sha256 = "caf516464966470c075c33fae53c33ada5f32f1d43dbeaaea7388fe6e006d001",
+            strip_prefix = "bazel-toolchains-3.4.2",
             urls = [
-                "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.4.1/bazel-toolchains-3.4.1.tar.gz",
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/3.4.1.tar.gz",
+                "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.4.2/bazel-toolchains-3.4.2.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/3.4.2.tar.gz",
             ],
         )
 

--- a/load.bzl
+++ b/load.bzl
@@ -58,15 +58,15 @@ def repositories():
         )
 
     # Check https://github.com/bazelbuild/rules_go/releases for new releases
-    # v0.22.11 supports Golang 1.15.0
+    # v0.23.9 supports Golang 1.15.1
     # If this is updated, please ensure that bazel-toolchains is also updated
     if not native.existing_rule("io_bazel_rules_go"):
         http_archive(
             name = "io_bazel_rules_go",
-            sha256 = "e02b302e8b6cb4a771feba99d36d04b13947ef22f51bea38632c0ab885cabe12",
+            sha256 = "be9b8be722745ff475051a2f37ebad9e234d48635d9e6d70f8b96c000336fc8d",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.22.11/rules_go-v0.22.11.tar.gz",
-                "https://github.com/bazelbuild/rules_go/releases/download/v0.22.11/rules_go-v0.22.11.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.23.9/rules_go-v0.23.9.tar.gz",
+                "https://github.com/bazelbuild/rules_go/releases/download/v0.23.9/rules_go-v0.23.9.tar.gz",
             ],
         )
 

--- a/repos.bzl
+++ b/repos.bzl
@@ -62,17 +62,30 @@ def repo_infra_patches():
         sum = "h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=",
         version = "v1.3.3",
     )
+
+    # Must be kept in sync with rules_go version
+    # To update this:
+    # 1. Navigate to https://github.com/bazelbuild/rules_go/tree/<new-rules_go-version>/go/private/repositories.bzl
+    # 2. Note the golang.org/x/tools repo SHA
+    #    Example: https://github.com/bazelbuild/rules_go/blob/9429f5029721210fbe24f8543d6c7b26e50a3b94/go/private/repositories.bzl#L76-L79
+    # 3. Query for the module info at that SHA
+    #    Example: go mod download -x -json golang.org/x/tools@2bc93b1c0c88b2406b967fcd19a623d1ff9ea0cd
+    # 4. Note the "Sum" value (NOT "GoModSum") and update the "sum" parameter below
+    # 5. Run ./hack/update-bazel.sh
     go_repository(
-        name = "org_golang_x_tools",  # Must keep in sync with rules_go version
+        name = "org_golang_x_tools",
         build_file_generation = "on",
         build_file_proto_mode = "disable",
         importpath = "golang.org/x/tools",
         patch_args = ["-p1"],
         patches = [
-            "@io_bazel_rules_go//third_party:org_golang_x_tools-extras.patch",  # Add go_tool_library targets
+            # extras adds go_tool_library rules for packages under
+            # go/analysis/passes and their dependencies. These are needed by
+            # nogo.
+            "@io_bazel_rules_go//third_party:org_golang_x_tools-extras.patch",
         ],
-        sum = "h1:zE128a8BUJqwFqwi8LxUnOdV3eSOGIzDhiIV/QW8eXc=",
-        version = "v0.0.0-20200221191710-57f3fb51f507",
+        sum = "h1:4j84u0sokprDu3IdSYHJMmou+YSLflMz8p7yAx/QI4g=",
+        version = "v0.0.0-20200512131952-2bc93b1c0c88",
     )
 
 def go_repositories():


### PR DESCRIPTION
- Update rules_go to 0.23.9 to support go1.15.1
- Update bazel_skylib to 1.0.3
- Update bazel_toolchains to 3.4.2

Tracking issue: https://github.com/kubernetes/release/issues/1517
/assign @Verolop @fejta @hasheddan 
cc: @kubernetes/release-engineering 