### PR TITLE
Support go1.15.2

### DIFF
--- a/load.bzl
+++ b/load.bzl
@@ -58,15 +58,15 @@ def repositories():
         )
 
     # Check https://github.com/bazelbuild/rules_go/releases for new releases
-    # v0.23.9 supports Golang 1.15.1
+    # v0.23.10 supports Golang 1.15.2
     # If this is updated, please ensure that bazel-toolchains is also updated
     if not native.existing_rule("io_bazel_rules_go"):
         http_archive(
             name = "io_bazel_rules_go",
-            sha256 = "be9b8be722745ff475051a2f37ebad9e234d48635d9e6d70f8b96c000336fc8d",
+            sha256 = "d9a9d51999acc7d60a5b58e20b391b907b3eaa9c670c1faa07c5e4a93bd8da36",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.23.9/rules_go-v0.23.9.tar.gz",
-                "https://github.com/bazelbuild/rules_go/releases/download/v0.23.9/rules_go-v0.23.9.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.23.10/rules_go-v0.23.10.tar.gz",
+                "https://github.com/bazelbuild/rules_go/releases/download/v0.23.10/rules_go-v0.23.10.tar.gz",
             ],
         )
 

--- a/load.bzl
+++ b/load.bzl
@@ -38,11 +38,11 @@ def repositories():
     if not native.existing_rule("bazel_toolchains"):
         http_archive(
             name = "bazel_toolchains",
-            sha256 = "caf516464966470c075c33fae53c33ada5f32f1d43dbeaaea7388fe6e006d001",
-            strip_prefix = "bazel-toolchains-3.4.2",
+            sha256 = "89a053218639b1c5e3589a859bb310e0a402dedbe4ee369560e66026ae5ef1f2",
+            strip_prefix = "bazel-toolchains-3.5.0",
             urls = [
-                "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.4.2/bazel-toolchains-3.4.2.tar.gz",
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/3.4.2.tar.gz",
+                "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.5.0/bazel-toolchains-3.5.0.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/3.5.0.tar.gz",
             ],
         )
 

--- a/repos.bzl
+++ b/repos.bzl
@@ -51,27 +51,34 @@ def repo_infra_go_repositories():
     go_repositories()
     repo_infra_patches()
 
+# THESE REQUIRE CUSTOM EDITS. PLEASE MAINTAIN.
+#
+# Must be kept in sync with rules_go version
+# To update these:
+# 1. Navigate to https://github.com/bazelbuild/rules_go/tree/<new-rules_go-version>/go/private/repositories.bzl
+# 2. Note the golang.org/x/tools repo SHA
+#    Example: https://github.com/bazelbuild/rules_go/blob/9429f5029721210fbe24f8543d6c7b26e50a3b94/go/private/repositories.bzl#L76-L79
+# 3. Query for the module info at that SHA
+#    Example: go mod download -x -json golang.org/x/tools@2bc93b1c0c88b2406b967fcd19a623d1ff9ea0cd
+# 4. Note the "Sum" value (NOT "GoModSum") and update the "sum" parameter below
+# 5. Run ./hack/update-bazel.sh
 def repo_infra_patches():
-    # These require custom edits, please maintain
-
+    # Up-to-date as of 9/10/2020
     go_repository(
         name = "com_github_golang_protobuf",
         build_file_generation = "on",
         build_file_proto_mode = "disable_global",  # Avoid import cyle
         importpath = "github.com/golang/protobuf",
-        sum = "h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=",
-        version = "v1.3.3",
+        patch_args = ["-p1"],
+        patches = [
+            # additional targets may depend on generated code for well known types
+            "@io_bazel_rules_go//third_party:com_github_golang_protobuf-extras.patch",
+        ],
+        sum = "h1:ZFgWrT+bLgsYPirOnRfKLYJLvssAegOj/hgyMFdJZe0=",
+        version = "v1.4.1",
     )
 
-    # Must be kept in sync with rules_go version
-    # To update this:
-    # 1. Navigate to https://github.com/bazelbuild/rules_go/tree/<new-rules_go-version>/go/private/repositories.bzl
-    # 2. Note the golang.org/x/tools repo SHA
-    #    Example: https://github.com/bazelbuild/rules_go/blob/9429f5029721210fbe24f8543d6c7b26e50a3b94/go/private/repositories.bzl#L76-L79
-    # 3. Query for the module info at that SHA
-    #    Example: go mod download -x -json golang.org/x/tools@2bc93b1c0c88b2406b967fcd19a623d1ff9ea0cd
-    # 4. Note the "Sum" value (NOT "GoModSum") and update the "sum" parameter below
-    # 5. Run ./hack/update-bazel.sh
+    # Up-to-date as of 9/10/2020
     go_repository(
         name = "org_golang_x_tools",
         build_file_generation = "on",


### PR DESCRIPTION
**Needed for go1.15.2 update: https://github.com/kubernetes/release/issues/1517**

- Update rules_go to 0.23.10 to support go1.15.2
- Update golang/protobuf to v1.4.1 (to match rules_go@v0.23.10)
- Update bazel_toolchains to 3.5.0

/assign @hasheddan @fejta @mikedanese @Verolop 
cc: @kubernetes/release-engineering 
