### PR TITLE
Fix _go_genrule_impl in build env where src files cannot be moved

### DIFF
--- a/defs/go.bzl
+++ b/defs/go.bzl
@@ -49,7 +49,7 @@ def _go_genrule_impl(ctx):
             args.add(target.path)
 
             ctx.actions.run(
-                executable = "mv",
+                executable = "cp",
                 arguments = [args],
                 inputs = [srcfile],
                 outputs = [target],


### PR DESCRIPTION
Use a `cp` operation instead of `mv`.

Fixes: https://github.com/kubernetes/repo-infra/issues/211

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @fejta @mikedanese 
cc: @jmillikin-stripe