### PR TITLE
carry patch to not override TMPDIR in go_test runner

### DIFF
--- a/load.bzl
+++ b/load.bzl
@@ -67,10 +67,16 @@ def repositories():
                 "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.25.1/rules_go-v0.25.1.tar.gz",
                 "https://github.com/bazelbuild/rules_go/releases/download/v0.25.1/rules_go-v0.25.1.tar.gz",
             ],
+            patch_args = ["-p1"],
+            patches = [
+                # Don't override TMPDIR in test runner.  See
+                # https://github.com/bazelbuild/rules_go/issues/2776 for
+                # details.
+                "@io_k8s_repo_infra//third_party/io_bazel_rules_go:dont-set-TEST_TMPDIR-to-TMPDIR-in-the-test-runner.patch",
+            ],
         )
 
     # https://github.com/bazelbuild/bazel-gazelle#running-gazelle-with-bazel
-    # v0.21 needs rules_go 0.23
     if not native.existing_rule("bazel_gazelle"):
         http_archive(
             name = "bazel_gazelle",

--- a/third_party/io_bazel_rules_go/BUILD
+++ b/third_party/io_bazel_rules_go/BUILD
@@ -1,0 +1,3 @@
+exports_files([
+    "dont-set-TEST_TMPDIR-to-TMPDIR-in-the-test-runner.patch",
+])

--- a/third_party/io_bazel_rules_go/dont-set-TEST_TMPDIR-to-TMPDIR-in-the-test-runner.patch
+++ b/third_party/io_bazel_rules_go/dont-set-TEST_TMPDIR-to-TMPDIR-in-the-test-runner.patch
@@ -1,0 +1,30 @@
+From d25e4d99b91901ef36ac118129b909e3c5f2d472 Mon Sep 17 00:00:00 2001
+From: Mike Danese <mikedanese@google.com>
+Date: Wed, 6 Jan 2021 18:25:29 -0800
+Subject: [PATCH] dont set TEST_TMPDIR to TMPDIR in the test runner
+
+This is a breaking change.
+
+Partially-Reverts: 9c1568a7f510fe306a59f8d09e91579a71f5e08c
+Fixes: #2776
+---
+ go/tools/bzltestutil/init.go | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/go/tools/bzltestutil/init.go b/go/tools/bzltestutil/init.go
+index 797ed242..ca9852ed 100644
+--- a/go/tools/bzltestutil/init.go
++++ b/go/tools/bzltestutil/init.go
+@@ -57,9 +57,4 @@ func init() {
+ 			os.Setenv("PWD", abs)
+ 		}
+ 	}
+-
+-	// Setup the bazel tmpdir as the go tmpdir.
+-	if tmpDir, ok := os.LookupEnv("TEST_TMPDIR"); ok {
+-		os.Setenv("TMPDIR", tmpDir)
+-	}
+ }
+-- 
+2.29.2.729.g45daf8777d-goog
+


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_go/issues/2776
Partial revert of https://github.com/bazelbuild/rules_go/commit/9c1568a7f510fe306a59f8d09e91579a71f5e08c

cc @justaugustus 