### PR TITLE
Update bazel_toolchains to 3.7.2

### DIFF
--- a/load.bzl
+++ b/load.bzl
@@ -38,11 +38,11 @@ def repositories():
     if not native.existing_rule("bazel_toolchains"):
         http_archive(
             name = "bazel_toolchains",
-            sha256 = "8e0633dfb59f704594f19ae996a35650747adc621ada5e8b9fb588f808c89cb0",
-            strip_prefix = "bazel-toolchains-3.7.0",
+            sha256 = "1caf8584434d3e31be674067996be787cfa511fda2a0f05811131b588886477f",
+            strip_prefix = "bazel-toolchains-3.7.2",
             urls = [
-                "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.7.0/bazel-toolchains-3.7.0.tar.gz",
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/3.7.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-toolchains/releases/download/3.7.2/bazel-toolchains-3.7.2.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/3.7.2.tar.gz",
             ],
         )
 


### PR DESCRIPTION
Needed for go1.15.7 update: https://github.com/kubernetes/release/issues/1851

 ~- Update rules_go to 0.24.11 to support go1.15.7~
 - Update bazel_toolchains to 3.7.2

rules_go release: https://github.com/bazelbuild/rules_go/releases

/hold to see if is correct

/assign @justaugustus @hasheddan @fejta @mikedanese
cc: @kubernetes/release-engineering