### PR TITLE
WORKSPACE: Don't force go version in `configure()` directive

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,6 +7,6 @@ repositories()
 
 load("//:repos.bzl", "configure", "repo_infra_go_repositories")
 
-configure(override_go_version = "1.15.11")
+configure()
 
 repo_infra_go_repositories()


### PR DESCRIPTION
Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @hasheddan @cpanato @puerco 
ref: https://github.com/kubernetes/release/issues/1984, https://kubernetes.slack.com/archives/C2C40FMNF/p1617783514267200?thread_ts=1617365695.206200&cid=C2C40FMNF, https://kubernetes.slack.com/archives/GKEA5EL67/p1618421701018300?thread_ts=1618419664.017100&cid=GKEA5EL67