### PR TITLE
Allow go 1.17 build constraints in `verify_boilerplate.py`

### DIFF
--- a/hack/verify_boilerplate.py
+++ b/hack/verify_boilerplate.py
@@ -221,7 +221,7 @@ def get_regexs():
     # dates can be any year between 2014 and the current year, company holder names can be anything
     regexs["date"] = re.compile(get_dates())
     # strip // +build \n\n build constraints
-    regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n",
+    regexs["go_build_constraints"] = re.compile(r"^(//( \+build|go:build).*\n)+\n",
                                                 re.MULTILINE)
     # strip #!.* from shell/python scripts
     regexs["shebang"] = re.compile(r"^(#!.*\n)\n*", re.MULTILINE)


### PR DESCRIPTION
The go command understands //go:build lines and prefers them over //
+build lines from go 1.17. The new syntax uses boolean expressions, just
like Go, and should be less error-prone.

The boilerplate verification scripts will now skip those lines as well.

Ref: https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md
