### PR TITLE
verify-boilerplate: check generated files for YEAR

### DIFF
--- a/hack/verify_boilerplate.py
+++ b/hack/verify_boilerplate.py
@@ -125,7 +125,7 @@ def file_passes(filename, refs, regexs):  # pylint: disable=too-many-locals
 
     # check if we encounter a 'YEAR' placeholder if the file is generated
     if is_generated(file_data):
-        for i, line in enumerate(ref):
+        for i, line in enumerate(data):
             if "Copyright YEAR" in line:
                 return False
 


### PR DESCRIPTION
Previously we were checking the boilerplate header for the YEAR
placeholder, and if it exited, marking the generated file as incorrect.
It seems like the correct check to be doing would be to check the
generated file for the placeholder.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @fejta @pmorie 