### PR TITLE
if the file is a generated and does not have date stop the checks

### DIFF
--- a/hack/verify_boilerplate.py
+++ b/hack/verify_boilerplate.py
@@ -128,6 +128,7 @@ def file_passes(filename, refs, regexs):  # pylint: disable=too-many-locals
         for i, line in enumerate(data):
             if "Copyright YEAR" in line:
                 return False
+        return True
 
     year = regexs["year"]
     for datum in data:


### PR DESCRIPTION
in a generated go file that does not have the date the current boilerplate is failing, because it tries to find a date where does not exist.

if is a generated file and passes in the check for that we should return and not perform the year validation


/assign @saschagrunert @justaugustus