### PR TITLE
Sync OWNERS, OWNERS_ALIASES and SECURITY_CONTACTS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,21 +1,18 @@
-approvers:
-- BenTheElder
-- clarketm
-- fejta
-- justaugustus
-- mikedanese
+# See the OWNERS docs at https://go.k8s.io/owners
 
+approvers:
+  - sig-release-leads
+  - release-engineering-approvers
 reviewers:
-- BenTheElder
-- clarketm
-- fejta
-- justaugustus
-- mikedanese
-- Verolop
+  - release-engineering-reviewers
 
 emeritus_approvers:
-- ixdy
+  - BenTheElder
+  - clarketm
+  - fejta
+  - ixdy
+  - mikedanese
 
 labels:
-- sig/release
-- area/release-eng
+  - sig/release
+  - area/release-eng

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,25 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+aliases:
+  sig-release-leads:
+    - cpanato # SIG Technical Lead
+    - jeremyrickard # SIG Chair
+    - justaugustus # SIG Chair
+    - puerco # SIG Technical Lead
+    - saschagrunert # SIG Chair
+    - Verolop # SIG Technical Lead
+  release-engineering-approvers:
+    - cici37 # Release Manager
+    - cpanato # subproject owner / Release Manager
+    - jeremyrickard # subproject owner / Release Manager
+    - justaugustus # subproject owner / Release Manager
+    - palnabarun # Release Manager
+    - puerco # subproject owner / Release Manager
+    - saschagrunert # subproject owner / Release Manager
+    - xmudrii # Release Manager
+    - Verolop # subproject owner / Release Manager
+  release-engineering-reviewers:
+    - ameukam # Release Manager Associate
+    - jimangel # Release Manager Associate
+    - jrsapi # Release Manager Associate
+    - salaxander # Release Manager Associate

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -10,5 +10,9 @@
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
-ixdy
-mikedanese
+cpanato
+jeremyrickard
+justaugustus
+puerco
+saschagrunert
+Verolop


### PR DESCRIPTION
- Convert OWNERS to use standard release-engineering aliases instead of hardcoded names
- Create OWNERS_ALIASES with sig-release-leads, release-engineering-approvers, and release-engineering-reviewers
- Move inactive maintainers (BenTheElder, clarketm, fejta, ixdy, mikedanese) to emeritus_approvers
- Update SECURITY_CONTACTS to match current SIG Release leads