### PR TITLE
fix-ci

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,9 +35,9 @@ jobs:
 
     steps:
     - name: "checkout-repo"
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: "setup-cache"
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ matrix.cache-paths }}
         key: ${{ runner.os }}-${{ hashFiles('.bazelversion') }}


### PR DESCRIPTION
Fix CI. See failure:

```
Error: The actions actions/checkout@v4 and actions/cache@v4 are not allowed in kubernetes/repo-infra because all actions must be pinned to a full-length commit SHA.
```
